### PR TITLE
Add execution_counts to execute_result outputs

### DIFF
--- a/site/en/tools/notebook_magic.ipynb
+++ b/site/en/tools/notebook_magic.ipynb
@@ -406,7 +406,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -614,7 +615,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -872,7 +874,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -1133,7 +1136,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -1381,7 +1385,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -1677,7 +1682,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -1990,7 +1996,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -2251,7 +2258,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -2531,7 +2539,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -2574,7 +2583,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -2869,7 +2879,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -2899,7 +2910,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -3153,7 +3165,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -3435,7 +3448,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -3747,7 +3761,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -3966,7 +3981,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -4185,7 +4201,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -4409,7 +4426,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -4689,7 +4707,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -4954,7 +4973,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [
@@ -5220,7 +5240,8 @@
             ]
           },
           "metadata": {},
-          "output_type": "execute_result"
+          "output_type": "execute_result",
+          "execution_count": null
         }
       ],
       "source": [


### PR DESCRIPTION
Seems like these are required too. Tested on [this branch](https://github.com/google/generative-ai-docs/blob/nbfmt/site/en/tools/notebook_magic.ipynb)

Change-Id: If920556be8310dfdd28c8e206445a2a83dbb0f9e