### PR TITLE
Remove `open in colab` icon

### DIFF
--- a/site/en/tools/notebook_magic.ipynb
+++ b/site/en/tools/notebook_magic.ipynb
@@ -3,15 +3,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/markmcd/generative-ai-docs/blob/magic/site/en/tools/notebook_magic.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "Tce3stUlHN0L"
       },
       "source": [
@@ -94,8 +85,7 @@
       "metadata": {
         "id": "4so2CHmPSxIU"
       },
-      "outputs": [
-      ],
+      "outputs": [],
       "source": [
         "%pip install -q google-generativeai"
       ]
@@ -1175,6 +1165,7 @@
       "cell_type": "code",
       "execution_count": 13,
       "metadata": {
+	"cellView": "form",
         "id": "DkdoxXqjD2Tm"
       },
       "outputs": [],


### PR DESCRIPTION
I think I ticked a box when saving from colab that added this. It's not a big deal, but it does point to my personal fork 😬

Also ran `nbfmt`, and fixed the "auth with sheets" step so that it is a closed form.