### PR TITLE
Only check website notebooks

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -28,7 +28,7 @@ jobs:
           readarray -t changed_notebooks < <(git diff --name-only main | grep '\.ipynb$' || true)
         else
           # Manual run, check everything
-          readarray -t changed_notebooks < <(find -name '*.ipynb')
+          readarray -t changed_notebooks < <(find site/en/ -name '*.ipynb')
         fi
         if [[ ${#changed_notebooks[@]} == 0 ]]; then
           echo "No notebooks modified in this pull request."
@@ -55,7 +55,7 @@ jobs:
           readarray -t changed_notebooks < <(git diff --name-only main | grep '\.ipynb$' || true)
         else
           # Manual run, check everything
-          readarray -t changed_notebooks < <(find -name '*.ipynb')
+          readarray -t changed_notebooks < <(find site/en/ -name '*.ipynb')
         fi
         if [[ ${#changed_notebooks[@]} == 0 ]]; then
           echo "No notebooks modified in this pull request."


### PR DESCRIPTION
This check was including the MakerSuite template notebooks, which are out of scope for the nblint/nbfmt checks.
