### PR TITLE
Talking Character: fix copy mediapipe to a wrong directory

### DIFF
--- a/demos/palm/web/talking-character/package.json
+++ b/demos/palm/web/talking-character/package.json
@@ -32,7 +32,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "cp -r third_party/mediapipe/ ./src/apis/ & react-scripts start",
+    "start": "cp -r third_party/mediapipe/ ./src/apis/mediapipe/ & react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
In npm strat script command, there is an error: copying scripts in `third_party/mediapipe/` to a wrong directory `./src/apis/`

In file `src/apis/mediapipe_audio_blendshapes.ts`, importing `createMediaPipeLib` from path `./mediapipe/web/graph_runner/graph_runner`, so `yarn start` or `npm start` will be failed.

Fix this issue by copying scripts in `third_party/mediapipe/`  to the directory `./src/apis/mediapipe/`