### PR TITLE
Consolidate titles in Python quickstart notebooks

### DIFF
--- a/site/en/tutorials/chat_quickstart.ipynb
+++ b/site/en/tutorials/chat_quickstart.ipynb
@@ -37,7 +37,7 @@
         "id": "yeadDkMiISin"
       },
       "source": [
-        "# PaLM API Chat Quickstart"
+        "# PaLM API: Chat quickstart with Python"
       ]
     },
     {
@@ -636,7 +636,7 @@
       "source": [
         "## Further reading\n",
         "\n",
-        "* Now that you've completed the quickstart, check out the complete [API reference]() to get a deeper understanding of the API."
+        "* Now that you've completed the quickstart, check out the complete [API reference](https://developers.generativeai.google/api/python/google/generativeai) to get a deeper understanding of the API."
       ]
     }
   ],

--- a/site/en/tutorials/embeddings_quickstart.ipynb
+++ b/site/en/tutorials/embeddings_quickstart.ipynb
@@ -37,7 +37,7 @@
         "id": "title"
       },
       "source": [
-        "# PaLM API Quickstart - Embeddings Edition"
+        "# PaLM API: Embeddings quickstart with Python"
       ]
     },
     {

--- a/site/en/tutorials/text_quickstart.ipynb
+++ b/site/en/tutorials/text_quickstart.ipynb
@@ -37,7 +37,7 @@
         "id": "yeadDkMiISin"
       },
       "source": [
-        "# PaLM API Quickstart - Text Edition"
+        "# PaLM API: Text Quickstart with Python"
       ]
     },
     {


### PR DESCRIPTION
These are the last remaining docs to fix titles so they're consistent across the quickstarts, and so they don't all show up the same in search results (either on-site or in the various engines).

I also found a weird broken markdown link, so fixed that too.

BUG=279128973