### PR TITLE
Revert "Revert "add safety settings to makersuite_text_prompt.ipynb""

### DIFF
--- a/templates/makersuite_text_prompt.ipynb
+++ b/templates/makersuite_text_prompt.ipynb
@@ -75,12 +75,14 @@
         "max_output_tokens = 1024 # @param {isTemplate: true}\n",
         "text_b64 = \"\" # @param {isTemplate: true}\n",
         "stop_sequences_b64 = \"\"  # @param {isTemplate: true}\n",
+        "safety_settings_b64 = \"\"  # @param {isTemplate: true}\n",
         "\n",
         "# Convert the prompt text param from a bae64 string to a string.\n",
         "text = base64.b64decode(text_b64).decode(\"utf-8\")\n",
         "\n",
-        "# Convert the stop_sequences param from a base64 string to a list.\n",
+        "# Convert the stop_sequences and safety_settings params from base64 strings to lists.\n",
         "stop_sequences = json.loads(base64.b64decode(stop_sequences_b64).decode(\"utf-8\"))\n",
+        "safety_settings = json.loads(base64.b64decode(safety_settings_b64).decode(\"utf-8\"))\n",
         "\n",
         "defaults = {\n",
         "  'model': model,\n",
@@ -90,6 +92,7 @@
         "  'top_p': top_p,\n",
         "  'max_output_tokens': max_output_tokens,\n",
         "  'stop_sequences': stop_sequences,\n",
+        "  'safety_settings': safety_settings,\n",
         "}"
       ]
     },


### PR DESCRIPTION
Reverts google/generative-ai-docs#43

This adds back in the code initially submitted in google/generative-ai-docs#42 now that the MakerSuite issue is fixed.