### PR TITLE
Add license header lint

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -1,0 +1,11 @@
+# Lint check for license headers.
+# See: https://github.com/googleapis/repo-automation-bots/tree/main/packages/header-checker-lint
+allowedCopyrightHolders:
+  - 'Google LLC'
+allowedLicenses:
+  - 'Apache-2.0'
+sourceFileExtensions:
+  - 'python'
+  - 'ts'
+  - 'js'
+  - 'java'


### PR DESCRIPTION
This adds a lint check (via the already-installed app [license-header-lint-gcf](https://github.com/apps/license-header-lint-gcf)) that should require new files to have an appropriate license header, like the cross tool.

This is redundant for notebooks, so I haven't added them to this list.