### PR TITLE
Remove unneeded extra message from template

### DIFF
--- a/templates/makersuite_chat_prompt.ipynb
+++ b/templates/makersuite_chat_prompt.ipynb
@@ -90,10 +90,6 @@
         "# Convert the model inputs from base64 strings to lists.\n",
         "examples = json.loads(base64.b64decode(examples_b64).decode(\"utf-8\"))\n",
         "messages = json.loads(base64.b64decode(messages_b64).decode(\"utf-8\"))\n",
-        "\n",
-        "# Add a user message to send to the model.\n",
-        "user_message = \"USER MESSAGE TO SEND\" # @param\n",
-        "messages.append(user_message)\n"
       ]
     },
     {


### PR DESCRIPTION
The final message to send to the model is now included in the messages array sent through URL parameters, removing the need for this code.

This should not be submitted until Wednesday June 14th ~1PM when the next update of MakerSuite happens, to coincide with the code changes on that side that change the URL parameters sent to this notebook.