### PR TITLE
Update LLMCaller.js to Preview URL and v1beta2 endpoint

### DIFF
--- a/demos/palm/web/travel-planner/src/apis/LLMCaller.js
+++ b/demos/palm/web/travel-planner/src/apis/LLMCaller.js
@@ -17,7 +17,7 @@
 export default class LLMCaller {
   constructor() {
     this.apiKey = import.meta.env.VITE_GOOGLE_GENERATIVE_LANGUAGE_API_KEY
-    this.baseUrl = 'https://autopush-generativelanguage.sandbox.googleapis.com';
+    this.baseUrl = 'https://generativelanguage.googleapis.com';
   }
 
   async sendPrompt(context, examples, messages, temperature = 0) {
@@ -30,7 +30,7 @@ export default class LLMCaller {
       }
 
       try {
-        const response = await fetch(`${this.baseUrl}/v1beta1/models/chat-bison-001:generateMessage?key=${this.apiKey}`, {
+        const response = await fetch(`${this.baseUrl}/v1beta2/models/chat-bison-001:generateMessage?key=${this.apiKey}`, {
           headers: {
             'Content-Type': 'application/json',
           },


### PR DESCRIPTION
Problem: PaLM API URL and endpoint was out of date as of June 17th 2023. 
Fix: Updated PALM URL and API endpoints to `generativelanguage.googleapis.com` and `v1beta2` as per https://developers.generativeai.google/guide/palm_api_overview 