### PR TITLE
Use prod URLs in mood-food and talking-character.

### DIFF
--- a/demos/palm/web/mood-food/src/apis/llmCaller.js
+++ b/demos/palm/web/mood-food/src/apis/llmCaller.js
@@ -17,7 +17,7 @@
 export default class LLMCaller {
   constructor() {
     this.apiKey = import.meta.env.VITE_GOOGLE_GENERATIVE_LANGUAGE_API_KEY;
-    this.baseUrl = 'https://autopush-generativelanguage.sandbox.googleapis.com';
+    this.baseUrl = 'https://generativelanguage.googleapis.com';
   }
 
   async sendPrompt(context, examples, messages, temperature = 0) {

--- a/demos/palm/web/talking-character/src/context/constants.ts
+++ b/demos/palm/web/talking-character/src/context/constants.ts
@@ -19,7 +19,7 @@ export const GOOGLE_CLOUD_API_KEY = '';  // Fill in your API key
 export const LANGUAGE_MODEL_API_KEY = '';  // Fill in your API key
 
 export const LANGUAGE_MODEL_BASE_URL =
-    'https://autopush-generativelanguage.sandbox.googleapis.com';
+    'https://generativelanguage.googleapis.com';
 
 export const LANGUAGE_MODEL_URL = `${
     LANGUAGE_MODEL_BASE_URL}/v1beta1/models/chat-bison-001:generateMessage?key=${


### PR DESCRIPTION
A couple of bug reports have come through for the demos referencing staging access issues (e.g. https://github.com/google/generative-ai-docs/issues/74 and https://github.com/google/generative-ai-docs/issues/73). These two references were all I could find that used non-prod API services. They also use `v1beta1`, but IIUC, that should still work for now.