### PR TITLE
Fix the AppEngine deployment runtime as NodeJS

### DIFF
--- a/demos/palm/web/travel-planner/app.yaml
+++ b/demos/palm/web/travel-planner/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: python310
+runtime: nodejs18
 
 handlers:
 - url: /


### PR DESCRIPTION
The app.yaml should use nodejs as runtime for React application. The python runtime will cause the deployment failure. The PR suggests using nodejs18 as stable Nodejs runtime.