### PR TITLE
Print API args before executing.

### DIFF
--- a/templates/makersuite_chat_prompt.ipynb
+++ b/templates/makersuite_chat_prompt.ipynb
@@ -43,7 +43,8 @@
         "!pip install google-generativeai\n",
         "import google.generativeai as palm\n",
         "import base64\n",
-        "import json"
+        "import json\n",
+        "import pprint"
       ]
     },
     {
@@ -89,7 +90,11 @@
         "\n",
         "# Convert the model inputs from base64 strings to lists.\n",
         "examples = json.loads(base64.b64decode(examples_b64).decode(\"utf-8\"))\n",
-        "messages = json.loads(base64.b64decode(messages_b64).decode(\"utf-8\"))\n"
+        "messages = json.loads(base64.b64decode(messages_b64).decode(\"utf-8\"))\n",
+        "\n",
+        "# Show what will be sent with the API call.\n",
+        "pprint.pprint(defaults | {\n",
+        "    'context': context, 'examples': examples, 'messages': messages})"
       ]
     },
     {

--- a/templates/makersuite_text_prompt.ipynb
+++ b/templates/makersuite_text_prompt.ipynb
@@ -43,7 +43,8 @@
         "!pip install google-generativeai\n",
         "import google.generativeai as palm\n",
         "import base64\n",
-        "import json"
+        "import json\n",
+        "import pprint"
       ]
     },
     {
@@ -93,7 +94,10 @@
         "  'max_output_tokens': max_output_tokens,\n",
         "  'stop_sequences': stop_sequences,\n",
         "  'safety_settings': safety_settings,\n",
-        "}"
+        "}\n",
+	"\n",
+	"# Show what will be sent with the API call.\n",
+	"pprint.pprint(defaults | {'prompt': text})"
       ]
     },
     {


### PR DESCRIPTION
Users have reported that the b64 encoded args are confusing, so hint that they can inspect them in Colab by pretty-printing the API args.