### PR TITLE
Add auto-tag for Doc Agent

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,9 @@
 'status:awaiting review':
 - '**/*'
 
+'demos:doc-agent':
+- demos/palm/python/docs-agent/**/*
+
 'examples:list-it':
 - demos/palm/web/list-it/**/*
 


### PR DESCRIPTION
## Description of the change
Add auto-tag for Doc Agent.

Will rename other tags to `demo:*` and update this config in a later PR to better align to current directory structure.

## Type of change
Choose one: Other

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [ ] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
