### PR TITLE
Limit embedding requests to text samples under 10k

### DIFF
--- a/site/en/examples/clustering_with_embeddings.ipynb
+++ b/site/en/examples/clustering_with_embeddings.ipynb
@@ -418,6 +418,8 @@
         "df_train['Label'] = newsgroups_train.target\n",
         "# Match label to target name index\n",
         "df_train['Class Name'] = df_train['Label'].map(newsgroups_train.target_names.__getitem__)\n",
+        "# Retain text samples that can be used in the gecko model.\n",
+        "df_train = df_train[df_train['Text'].str.len() < 10000]\n",
         "\n",
         "df_train"
       ]


### PR DESCRIPTION
## Description of the change
The `embeddings-gecko-001` model doesn't seem to like anything over 10k, so filter them out in the tutorial.

## Motivation
Bugfix

## Type of change
Choose one: Bug fix

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
