### PR TITLE
Add a sample Google Cloud Function script

### DIFF
--- a/examples/palm/python/google_cloud_functions/main.py
+++ b/examples/palm/python/google_cloud_functions/main.py
@@ -1,0 +1,39 @@
+import functions_framework
+import google.ai.generativelanguage as glm
+import google.generativeai as palm
+from google.oauth2 import credentials
+import json
+import requests
+
+SCOPES = [
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/generative-language.tuning',
+]
+
+def get_credentials():
+  """Generate scoped OAuth2 credentials."""
+  token_full_url = 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token?scopes=' + ','.join(SCOPES)
+  token_response = requests.get(token_full_url, headers={'Metadata-Flavor': 'Google'})
+  if token_response.status_code != 200:
+    raise ValueError(f'Cant auth - {token_response.status_code}: {token_response.text}')
+
+  token = json.loads(token_response.text)
+  return credentials.Credentials(token=token['access_token'])
+
+
+@functions_framework.http
+def load_model(request):
+  """Load a PaLM model using a service account."""
+
+  # Build a google.auth.credentials.Credentials object from the running service account's
+  # authorisation, with the desired scopes defined above.
+  o2_creds = get_credentials()
+  # Each PaLM API uses a different client, e.g. ModelServiceClient, TextServiceClient, etc.
+  # You will need to build the respective client for the API you are using.
+  model_client = glm.ModelServiceClient(credentials=o2_creds)
+
+  # Test tuning by passing name=tunedModels/your-model-id. You must ensure that the model is shared
+  # with the running service account, or you will see a permission denied error (in the logs).
+  model_name = request.args.get('name', 'models/text-bison-001')
+  model = palm.get_model(model_name, client=model_client)
+  return f'<pre>{model}</pre>'


### PR DESCRIPTION
## Description of the change
This illustrates how to use Cloud Functions with the PaLM API.

As the default service account is un-scoped, there is an extra step required to work with the API. This script can be dropped in to a GCF editor to get the service account authorised against the PaLM API.

## Motivation
A couple of users have gotten stuck doing this, so I figured we should drop a reference in here. If we don't want it in this repo I can dump it in a gist.

## Type of change
Choose one: Other

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
