### PR TITLE
Fixed issue #176

### DIFF
--- a/demos/palm/python/docs-agent/chatbot/launch.sh
+++ b/demos/palm/python/docs-agent/chatbot/launch.sh
@@ -35,4 +35,5 @@ export FLASK_PORT=$port
 export FLASK_APP=$name
 export FLASK_DEBUG=true
 
+#This ensures that the host is set to "localhost" directly in the flask run command.
 flask run --host=localhost --port=$FLASK_PORT

--- a/demos/palm/python/docs-agent/chatbot/launch.sh
+++ b/demos/palm/python/docs-agent/chatbot/launch.sh
@@ -35,4 +35,4 @@ export FLASK_PORT=$port
 export FLASK_APP=$name
 export FLASK_DEBUG=true
 
-flask run --host=$HOSTNAME --port=$FLASK_PORT
+flask run --host=localhost --port=$FLASK_PORT


### PR DESCRIPTION
## Description of the change
 Fixed issue  #176 

## Motivation
This problem occurs while running docs-agent `poetry run ./chatbot/launch.sh -p 5000`,  the host name is set to the computer name in  instead of local host in my case it was running on Archie:5000, but it was not working/Running , I tested this on another Linux machine but same issue #176  occurred, This change fixed this issue by changing `--host=$HOSTNAME` to `--host=localhost`


## Type of change
Bug fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
