### PR TITLE
Move the Chroma guide out of site/, into examples/

### DIFF
--- a/examples/gemini/python/vectordb_with_chroma/vectordb_with_chroma.ipynb
+++ b/examples/gemini/python/vectordb_with_chroma/vectordb_with_chroma.ipynb
@@ -48,13 +48,10 @@
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://ai.google.dev/examples/vectordb_with_chroma\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on Generative AI</a>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/examples/gemini/python/vectordb_with_chroma/vectordb_with_chroma.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/examples/vectordb_with_chroma.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/examples/vectordb_with_chroma.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/examples/gemini/python/vectordb_with_chroma/vectordb_with_chroma.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
         "</table>\n"
       ]
@@ -192,7 +189,7 @@
       "source": [
         "Key Point: Next, you will choose a model. Any embedding model will work for this tutorial, but for real applications it's important to choose a specific model and stick with it. The outputs of different models are not compatible with each other.\n",
         "\n",
-        "**Note**: At this time, the Gemini API is [only available in certain regions](https://developers.generativeai.google/available_regions)."
+        "**Note**: At this time, the Gemini API is [only available in certain regions](https://ai.google.dev/available_regions)."
       ]
     },
     {
@@ -803,7 +800,7 @@
       "source": [
         "## Next steps\n",
         "\n",
-        "To learn more about how you can use the embeddings, check out the [examples](../examples?keywords=embed) available. To learn how to use other services in the Gemini API, visit the [Python quickstart](../tutorials/python_quickstart.ipynb)."
+        "To learn more about how you can use the embeddings, check out the [examples](https://ai.google.dev/examples?keywords=embed) available. To learn how to use other services in the Gemini API, visit the [Python quickstart](../../../../site/en/tutorials/python_quickstart.ipynb)."
       ]
     }
   ],


### PR DESCRIPTION
So we don't break links (e.g. via colab) this should be merged in sync with cl/591176318.