### PR TITLE
Update pip install instructions for keras and keras-nlp

### DIFF
--- a/site/en/gemma/docs/lit_gemma.ipynb
+++ b/site/en/gemma/docs/lit_gemma.ipynb
@@ -208,7 +208,9 @@
       "outputs": [],
       "source": [
         "!pip install -q -U lit-nlp\n",
-        "!pip install -q -U keras keras-nlp"
+        "!pip uninstall -y umap-learn\n",
+        "!pip install -q -U keras-nlp\n",
+        "!pip install -q -U keras"
       ]
     },
     {


### PR DESCRIPTION
Fixing pip install instructions to use appropriate order as per https://keras.io/getting_started/#installing-keras-3