### PR TITLE
Minor tweaks to JAX Gemma docs

### DIFF
--- a/site/en/gemma/docs/jax_finetune.ipynb
+++ b/site/en/gemma/docs/jax_finetune.ipynb
@@ -1,1402 +1,1415 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Tce3stUlHN0L"
-      },
-      "source": [
-        "##### Copyright 2024 Google LLC."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "tuOe1ymfHZPu"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "N_yUpPhqrRrK"
-      },
-      "source": [
-        "# Fine-tuning Gemma using JAX and Flax"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-yDXE-RX835U"
-      },
-      "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/jax_finetune\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/google/generative-ai-docs/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://ai.google.dev/images/cloud-icon.svg\" width=\"40\" />Open in Vertex AI</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MUnQEMHBt3nc"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "Gemma is a family of lightweight, state-of-the-art open large language models, based on the Google DeepMind Gemini research and technology. This tutorial demonstrates how to fine-tune the Gemma 2B Instruct model for an English-French translation task using [Google DeepMind's `gemma` library](https://github.com/google-deepmind/gemma), [JAX](https://jax.readthedocs.io) (a high-performance numerical computing library), [Flax](https://flax.readthedocs.io) (the JAX-based neural network library), [Chex](https://chex.readthedocs.io/en/latest/) (a library of utilities for writing reliable JAX code), [Optax](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), and the [MTNT (Machine Translation of Noisy Text) dataset](https://arxiv.org/abs/1809.00388). Although Flax is not used directly in this notebook, Flax was used to create Gemma.\n",
-        "\n",
-        "The `gemma` library was written with JAX, Flax, [Orbax](https://orbax.readthedocs.io/) (a JAX-based library for training utilities like checkpointing), and [SentencePiece](https://github.com/google/sentencepiece) (a tokenizer/detokenizer library).\n",
-        "\n",
-        "**Note:** This notebook runs on A100 GPU in Google Colab. Free Colab hardware acceleration is *insufficient* to run this notebook, as it requires plenty of host memory, such as A100 GPU (available in Colab Pro) or at least Google Cloud TPU v3-8. You can use [a Kaggle VM notebook](https://www.kaggle.com/), which provides free TPU v3-8 acceleration; or [Google Cloud TPU](https://cloud.google.com/tpu?hl=en) offers TPU v3 and newer. Currently, Google Colab provides TPU v2, which is insufficient for this tutorial."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dbRLI7Q4-8Ve"
-      },
-      "source": [
-        "## Setup"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "n8Ku4iK6PnC0"
-      },
-      "source": [
-        "### 1. Set up Kaggle access for Gemma\n",
-        "\n",
-        "To complete this tutorial, you first need to follow the setup instructions at [Gemma setup](https://ai.google.dev/gemma/docs/setup), which show you how to do the following:\n",
-        "\n",
-        "* Get access to Gemma on [kaggle.com](https://www.kaggle.com/models/google/gemma/).\n",
-        "* Select a Colab runtime with sufficient resources to run the Gemma model.\n",
-        "* Generate and configure a Kaggle username and API key.\n",
-        "\n",
-        "After you've completed the Gemma setup, move on to the next section, where you'll set environment variables for your Colab environment.\n",
-        "\n",
-        "### Set environment variables\n",
-        "\n",
-        "Set environment variables for `KAGGLE_USERNAME` and `KAGGLE_KEY`. When prompted with the \"Grant access?\" messages, agree to provide secret access."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "AVH6Y4k2964n"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "from google.colab import userdata # `userdata` is a Colab API.\n",
-        "\n",
-        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get('KAGGLE_USERNAME')\n",
-        "os.environ[\"KAGGLE_KEY\"] = userdata.get('KAGGLE_KEY')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "m1UE1CEnE9ql"
-      },
-      "source": [
-        "### 2. Install the `gemma` library\n",
-        "\n",
-        "Free Colab hardware acceleration is currently *insufficient* to run this notebook. If you are using [Colab Pay As You Go or Colab Pro](https://colab.research.google.com/signup), click on **Edit** > **Notebook settings** > Select **A100 GPU** > **Save** to enable hardware acceleration.\n",
-        "\n",
-        "Next, you need to install the Google DeepMind `gemma` library from [`github.com/google-deepmind/gemma`](https://github.com/google-deepmind/gemma). If you get an error about \"pip's dependency resolver\", you can usually ignore it.\n",
-        "\n",
-        "**Note:** By installing `gemma`, you will also install [`flax`](https://flax.readthedocs.io), core [`jax`](https://jax.readthedocs.io), [`optax`](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), [`orbax`](https://orbax.readthedocs.io/), and [`sentencepiece`](https://github.com/google/sentencepiece)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "id": "XpSw-_4EEcoY"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
-            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
-            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.7/133.7 kB\u001b[0m \u001b[31m1.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.4/244.4 kB\u001b[0m \u001b[31m5.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h  Building wheel for gemma (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-            "tensorflow-metadata 1.14.0 requires absl-py<2.0.0,>=0.9, but you have absl-py 2.1.0 which is incompatible.\u001b[0m\u001b[31m\n",
-            "\u001b[0m"
-          ]
-        }
-      ],
-      "source": [
-        "!pip install -q git+https://github.com/google-deepmind/gemma.git"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-mRkkT-iPYoq"
-      },
-      "source": [
-        "### 3. Import libraries\n",
-        "\n",
-        "This notebook uses [Flax](https://flax.readthedocs.io) (for neural networks), core [JAX](https://jax.readthedocs.io), [SentencePiece](https://github.com/google/sentencepiece) (for tokenization), [Chex](https://chex.readthedocs.io/en/latest/) (a library of utilities for writing reliable JAX code), and TensorFlow Datasets."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "id": "ChMf1H4mPVx_"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "import enum\n",
-        "import re\n",
-        "import string\n",
-        "\n",
-        "import chex\n",
-        "import jax\n",
-        "import jax.numpy as jnp\n",
-        "import optax\n",
-        "\n",
-        "import tensorflow as tf\n",
-        "import tensorflow_datasets as tfds\n",
-        "\n",
-        "from gemma import params as params_lib\n",
-        "from gemma import sampler as sampler_lib\n",
-        "from gemma import transformer as transformer_lib\n",
-        "import sentencepiece as spm"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "oNgKIkxMOsit"
-      },
-      "source": [
-        "## Load the Gemma model\n",
-        "\n",
-        "Load the Gemma model with [`kagglehub.model_download`](https://github.com/Kaggle/kagglehub/blob/bddefc718182282882b72f814d407d89e5d178c4/src/kagglehub/models.py#L12), which takes three arguments:\n",
-        "\n",
-        "- `handle`: The model handle from Kaggle\n",
-        "- `path`: (Optional string) The local path\n",
-        "- `force_download`: (Optional boolean) Forces to re-download the model\n",
-        "\n",
-        "**Note:** Be mindful that the `gemma-2b-it` model is around 3.7Gb in size."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "id": "X-i10429N-g2"
-      },
-      "outputs": [],
-      "source": [
-        "GEMMA_VARIANT = '2b-it' # @param ['2b', '2b-it'] {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "id": "j_QdPAGyO5zl"
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Downloading from https://www.kaggle.com/api/v1/models/google/gemma/flax/2b-it/2/download...\n",
-            "100%|██████████| 3.67G/3.67G [00:26<00:00, 147MB/s]\n",
-            "Extracting model files...\n"
-          ]
-        }
-      ],
-      "source": [
-        "import kagglehub\n",
-        "\n",
-        "GEMMA_PATH = kagglehub.model_download(f'google/gemma/flax/{GEMMA_VARIANT}')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "id": "cjnXlLkWcHIy"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "GEMMA_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2\n"
-          ]
-        }
-      ],
-      "source": [
-        "print('GEMMA_PATH:', GEMMA_PATH)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "E1HzOpDcM04q"
-      },
-      "source": [
-        "**Note:** The path from the output above is where the model weights and tokenizer are saved locally, you will need them for later."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6ytvcJ8FPEMm"
-      },
-      "source": [
-        "Check the location of the model weights and the tokenizer, then set the path variables. The tokenizer directory will be in the main directory where you downloaded the model, while the model weights will be in a sub-directory. For example:\n",
-        "\n",
-        "- The `tokenizer.model` file will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2`).\n",
-        "- The model checkpoint will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2/2b-it`)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "id": "JAwXvpzbuiB5"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CKPT_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/2b-it\n",
-            "TOKENIZER_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/tokenizer.model\n"
-          ]
-        }
-      ],
-      "source": [
-        "CKPT_PATH = os.path.join(GEMMA_PATH, GEMMA_VARIANT)\n",
-        "TOKENIZER_PATH = os.path.join(GEMMA_PATH, 'tokenizer.model')\n",
-        "print('CKPT_PATH:', CKPT_PATH)\n",
-        "print('TOKENIZER_PATH:', TOKENIZER_PATH)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "U800JRcJVIlF"
-      },
-      "source": [
-        "## Load and prepare the MTNT dataset and the Gemma tokenizer\n",
-        "\n",
-        "You will use the [MTNT (Machine Translation of Noisy Text)](https://arxiv.org/abs/1809.00388) dataset, which is available from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/mtnt).\n",
-        "\n",
-        "Download the English-to-French dataset portion of the MTNT dataset, and then sample two examples. Each sample in the dataset contains two entries: `src`: the original English sentence; and `dst`: the corresponding French translation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "id": "pg8SfQH0EcoY"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Downloading and preparing dataset 35.08 MiB (download: 35.08 MiB, generated: 11.33 MiB, total: 46.41 MiB) to /root/tensorflow_datasets/mtnt/en-fr/1.0.0...\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "4ec9a4a2b77f41e4a7435359338b140c",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Dl Completed...: 0 url [00:00, ? url/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "f799eec281194b80b8f260224df50ae3",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Dl Size...: 0 MiB [00:00, ? MiB/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "4804ce26e0b84a5e8a9774bb5dcd1ebc",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Extraction completed...: 0 file [00:00, ? file/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "04b3ecfe7275446e816804c01da57572",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Generating splits...:   0%|          | 0/3 [00:00<?, ? splits/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "8e2b3d7109ea47a4a28bf02f0683c50b",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Generating train examples...:   0%|          | 0/35692 [00:00<?, ? examples/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "da26bf08c7be4a79b64e94b3f5ad028c",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-train.tfrecord*...:   0%|          …"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "c864366a50e94b4fbc38085f0f602dca",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Generating test examples...:   0%|          | 0/1020 [00:00<?, ? examples/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "ad5ce2585efc45899da7b33ac0663005",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-test.tfrecord*...:   0%|          |…"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "384b494a52a54757ab3fdefee721327c",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Generating valid examples...:   0%|          | 0/811 [00:00<?, ? examples/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "943840b94fc64a05baf9c8e057dc3b85",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-valid.tfrecord*...:   0%|          …"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Dataset mtnt downloaded and prepared to /root/tensorflow_datasets/mtnt/en-fr/1.0.0. Subsequent calls will reuse this data.\n",
-            "Example 0:\n",
-            "dst: b'Le groupe de \" toutes les \\xc3\\xa9toiles potentielles de la conf\\xc3\\xa9rence de l\\'Est mais qui ne s\\'en sortent pas dans le groupe de l\\'Ouest \".'\n",
-            "src: b'The group of \\xe2\\x80\\x9ceastern conference potential all stars but not making it in the West\\xe2\\x80\\x9d group.'\n",
-            "\n",
-            "Example 1:\n",
-            "dst: b\"Kameron est-elle un peu aigrie de son manque de temps \\xc3\\xa0 l'\\xc3\\xa9cran ?\"\n",
-            "src: b'Is Kameron a Little Salty About Her Lack of Air Time?'\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "ds = tfds.load(\"mtnt/en-fr\", split=\"train\")\n",
-        "\n",
-        "ds = ds.take(2)\n",
-        "ds = ds.as_numpy_iterator()\n",
-        "\n",
-        "for idx, example in enumerate(ds):\n",
-        "  print(f'Example {idx}:')\n",
-        "  for key, val in example.items():\n",
-        "    print(f'{key}: {val}')\n",
-        "  print()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XlY3EYV6jXWR"
-      },
-      "source": [
-        "Load the Gemma tokenizer, constructed using [`sentencepiece.SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "id": "TpyG5YW1EcoY"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "True"
-            ]
-          },
-          "execution_count": 9,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "vocab = spm.SentencePieceProcessor()\n",
-        "vocab.Load(TOKENIZER_PATH)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Mk_CV0A1kR4K"
-      },
-      "source": [
-        "Customize the[`SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423) for the English-to-French translation task. Since you will be fine-tuning the English portion of the Gemma model, you need to make a few adjustments, such as:\n",
-        "\n",
-        "- *The input prefix*: Adding a common prefix to each input signals the translation task. For example, you could use a prompt with a prefix like `Translate this into French: [INPUT_SENTENCE]`.\n",
-        "\n",
-        "- *The translation start suffix*: Adding a suffix at the end of each prompt instructs the Gemma model exactly when to begin the translation process. A new line should do the job.\n",
-        "\n",
-        "- *Language model tokens*: Gemma models expect a \"beginning of sequence\" token at the beginning of each sequence, so adding an \"end of sequence\" token at the end of each training example should be sufficient.\n",
-        "\n",
-        "  Build a custom wrapper around the `SentencePieceProcessor` as follows:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "id": "L9cjK0uxEcoY"
-      },
-      "outputs": [],
-      "source": [
-        "class GemmaTokenizer:\n",
-        "\n",
-        "  def __init__(self,\n",
-        "               spm_processor: spm.SentencePieceProcessor):\n",
-        "    self._spm_processor = spm_processor\n",
-        "\n",
-        "  @property\n",
-        "  def pad_id(self) -> int:\n",
-        "    \"\"\"Fast access to the pad ID.\"\"\"\n",
-        "    return self._spm_processor.pad_id()\n",
-        "\n",
-        "  def tokenize(self,\n",
-        "               example: str | bytes,\n",
-        "               prefix: str = '',\n",
-        "               suffix: str = '',\n",
-        "               add_eos: bool = True) -> jax.Array:\n",
-        "    \"\"\"\n",
-        "    The tokenization function.\n",
-        "\n",
-        "    Args:\n",
-        "      example: Input string to tokenize.\n",
-        "      prefix:  Prefix to add to the input string.\n",
-        "      suffix:  Suffix to add to the input string.\n",
-        "      add_eos: If True, add an \"end of sentence\" token at the end of the output\n",
-        "               sequence.\n",
-        "    Returns:\n",
-        "      Tokens corresponding to the input string.\n",
-        "    \"\"\"\n",
-        "    int_list = [self._spm_processor.bos_id()]\n",
-        "    int_list.extend(self._spm_processor.EncodeAsIds(prefix + example + suffix))\n",
-        "    if add_eos:\n",
-        "      int_list.append(self._spm_processor.eos_id())\n",
-        "\n",
-        "    return jnp.array(int_list, dtype=jnp.int32)\n",
-        "\n",
-        "  def tokenize_tf_op(self,\n",
-        "                     str_tensor: tf.Tensor,\n",
-        "                     prefix: str = '',\n",
-        "                     suffix: str = '',\n",
-        "                     add_eos: bool = True) -> tf.Tensor:\n",
-        "    \"\"\"A TensorFlow operator for the tokenize function.\"\"\"\n",
-        "    encoded = tf.numpy_function(\n",
-        "        self.tokenize,\n",
-        "        [str_tensor, prefix, suffix, add_eos],\n",
-        "        tf.int32)\n",
-        "    encoded.set_shape([None])\n",
-        "    return encoded\n",
-        "\n",
-        "  def to_string(self, tokens: jax.Array) -> str:\n",
-        "    \"\"\"Convert an array of tokens to a string.\"\"\"\n",
-        "    return self._spm_processor.EncodeIds(tokens.tolist())"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "h-oJ2ziwxG1L"
-      },
-      "source": [
-        "Try it out by instantiating your new custom `GemmaTokenizer`, and then applying it on a small sample of the MTNT dataset:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "id": "xEA-97ioEcoY"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Example 0:\n",
-            "src: [     2  49688    736   1280   6987 235292    108    651   2778    576\n",
-            "   1080 104745  11982   5736    832   8995    901    780   3547    665\n",
-            "    575    573   4589 235369   2778 235265    108]\n",
-            "dst: [     2   2025  29653    581    664  16298   1437  55563  41435   7840\n",
-            "    581    683 111452    581    533 235303   9776   4108   2459    679\n",
-            "    485 235303    479   6728    579   1806   2499    709  29653    581\n",
-            "    533 235303 101323  16054      1]\n",
-            "\n",
-            "Example 1:\n",
-            "src: [     2  49688    736   1280   6987 235292    108   2437  87150    477\n",
-            "    476  11709 230461   8045   3636  40268    576   4252   4897 235336\n",
-            "    108]\n",
-            "dst: [     2 213606    477   1455 235290   3510    748   8268 191017   2809\n",
-            "    581   2032  69972    581  11495   1305    533 235303  65978   1654\n",
-            "      1]\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "tokenizer = GemmaTokenizer(vocab)\n",
-        "\n",
-        "def tokenize_source(tokenizer, example: tf.Tensor):\n",
-        "  return tokenizer.tokenize_tf_op(example,\n",
-        "                                  prefix='Translate this into French:\\n',\n",
-        "                                  suffix='\\n',\n",
-        "                                  add_eos=False)\n",
-        "def tokenize_destination(tokenizer, example: tf.Tensor):\n",
-        "  return tokenizer.tokenize_tf_op(example,\n",
-        "                                  add_eos=True)\n",
-        "\n",
-        "ds = tfds.load(\"mtnt/en-fr\",split=\"train\")\n",
-        "ds = ds.take(2)\n",
-        "ds = ds.map(lambda x: {'src': tokenize_source(tokenizer, x['src']),\n",
-        "                       'dst': tokenize_destination(tokenizer, x['dst'])})\n",
-        "ds = ds.as_numpy_iterator()\n",
-        "\n",
-        "for idx, example in enumerate(ds):\n",
-        "  print(f'Example {idx}:')\n",
-        "  for key, val in example.items():\n",
-        "    print(f'{key}: {val}')\n",
-        "  print()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qkY_hThVkkqF"
-      },
-      "source": [
-        "Build a data loader for the entire MTNT dataset:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {
-        "id": "Zm30Q2lnknmG"
-      },
-      "outputs": [],
-      "source": [
-        "@chex.dataclass(frozen=True)\n",
-        "class TrainingInput:\n",
-        "  # Input tokens provided to the model.\n",
-        "  input_tokens: jax.Array\n",
-        "\n",
-        "  # A mask that determines which tokens contribute to the target loss\n",
-        "  # calculation.\n",
-        "  target_mask: jax.Array\n",
-        "\n",
-        "class DatasetSplit(enum.Enum):\n",
-        "  TRAIN = 'train'\n",
-        "  VALIDATION = 'valid'\n",
-        "\n",
-        "class MTNTDatasetBuilder:\n",
-        "  \"\"\"The dataset builder for the MTNT dataset.\"\"\"\n",
-        "\n",
-        "  N_ITEMS = {DatasetSplit.TRAIN: 35_692,\n",
-        "             DatasetSplit.VALIDATION: 811}\n",
-        "\n",
-        "  BUFFER_SIZE_SHUFFLE = 10_000\n",
-        "  TRANSLATION_PREFIX = 'Translate this into French:\\n'\n",
-        "  TRANSLATION_SUFFIX = '\\n'\n",
-        "\n",
-        "  def __init__(self,\n",
-        "               tokenizer : GemmaTokenizer,\n",
-        "               max_seq_len: int):\n",
-        "    \"\"\"Constructor.\n",
-        "\n",
-        "    Args:\n",
-        "      tokenizer: Gemma tokenizer to use.\n",
-        "      max_seq_len: size of each sequence in a given batch.\n",
-        "    \"\"\"\n",
-        "    self._tokenizer = tokenizer\n",
-        "    self._base_data = {\n",
-        "        DatasetSplit.TRAIN: tfds.load(\"mtnt/en-fr\",split=\"train\"),\n",
-        "        DatasetSplit.VALIDATION: tfds.load(\"mtnt/en-fr\",split=\"valid\"),\n",
-        "    }\n",
-        "    self._max_seq_len = max_seq_len\n",
-        "\n",
-        "  def _tokenize_source(self, example: tf.Tensor):\n",
-        "    \"\"\"Tokenization function for the source.\"\"\"\n",
-        "    return self._tokenizer.tokenize_tf_op(example,\n",
-        "                                          prefix=self.TRANSLATION_PREFIX,\n",
-        "                                          suffix=self.TRANSLATION_SUFFIX,\n",
-        "                                          add_eos=False)\n",
-        "\n",
-        "  def _tokenize_destination(self, example: tf.Tensor):\n",
-        "    \"\"\"Tokenization function for the French translation.\"\"\"\n",
-        "    return self._tokenizer.tokenize_tf_op(example,\n",
-        "                                          add_eos=True)\n",
-        "\n",
-        "  def _pad_up_to_max_len(self,\n",
-        "                         input_tensor: tf.Tensor,\n",
-        "                         pad_value: int | bool,\n",
-        "                         ) -> tf.Tensor:\n",
-        "    \"\"\"Pad the given tensor up to sequence length of a batch.\"\"\"\n",
-        "    seq_len = tf.shape(input_tensor)[0]\n",
-        "    to_pad = tf.maximum(self._max_seq_len - seq_len, 0)\n",
-        "    return tf.pad(input_tensor,\n",
-        "                  [[0, to_pad]],\n",
-        "                  mode='CONSTANT',\n",
-        "                  constant_values=pad_value,\n",
-        "                  )\n",
-        "\n",
-        "  def _to_training_input(self,\n",
-        "                         src_tokens: jax.Array,\n",
-        "                         dst_tokens: jax.Array,\n",
-        "                         ) -> TrainingInput:\n",
-        "    \"\"\"Build a training input from a tuple of source and destination tokens.\"\"\"\n",
-        "\n",
-        "    # The input sequence fed to the model is simply the concatenation of the\n",
-        "    # source and the destination.\n",
-        "    tokens = tf.concat([src_tokens, dst_tokens], axis=0)\n",
-        "\n",
-        "    # To prevent the model from updating based on the source (input)\n",
-        "    # tokens, add a target mask to each input.\n",
-        "    q_mask = tf.zeros_like(src_tokens, dtype=tf.bool)\n",
-        "    a_mask = tf.ones_like(dst_tokens, dtype=tf.bool)\n",
-        "    mask = tf.concat([q_mask, a_mask], axis=0)\n",
-        "\n",
-        "    # If the output tokens sequence is smaller than the target sequence size,\n",
-        "    # then pad it with pad tokens.\n",
-        "    tokens = self._pad_up_to_max_len(tokens, self._tokenizer.pad_id)\n",
-        "\n",
-        "    # Don't want to perform the backward pass on the pad tokens.\n",
-        "    mask = self._pad_up_to_max_len(mask, False)\n",
-        "\n",
-        "    return TrainingInput(input_tokens=tokens, target_mask=mask)\n",
-        "\n",
-        "\n",
-        "  def get_train_dataset(self, batch_size: int, num_epochs: int):\n",
-        "    \"\"\"Build the training dataset.\"\"\"\n",
-        "\n",
-        "    # Tokenize each sample.\n",
-        "    ds = self._base_data[DatasetSplit.TRAIN].map(lambda x : (self._tokenize_source(x['src']),\n",
-        "                                                             self._tokenize_destination(x['dst'])))\n",
-        "\n",
-        "    # Convert the samples to training inputs.\n",
-        "    ds = ds.map(lambda x, y: self._to_training_input(x, y))\n",
-        "\n",
-        "    # Remove the samples that are too long.\n",
-        "    ds = ds.filter(lambda x: tf.shape(x.input_tokens)[0] <= self._max_seq_len)\n",
-        "\n",
-        "    # Shuffle the dataset.\n",
-        "    ds = ds.shuffle(buffer_size=self.BUFFER_SIZE_SHUFFLE)\n",
-        "\n",
-        "    # Repeat if necessary.\n",
-        "    ds = ds.repeat(num_epochs)\n",
-        "\n",
-        "    # Build batches.\n",
-        "    ds = ds.batch(batch_size, drop_remainder=True)\n",
-        "    return ds\n",
-        "\n",
-        "  def get_validation_dataset(self, batch_size: int):\n",
-        "    \"\"\"Build the validation dataset.\"\"\"\n",
-        "\n",
-        "    # Same steps as in `get_train_dataset`, but without shuffling and no repetition.\n",
-        "    ds = self._base_data[DatasetSplit.VALIDATION].map(lambda x : (self._tokenize_source(x['src']),\n",
-        "                                                                  self._tokenize_destination(x['dst'])))\n",
-        "    ds = ds.map(lambda x, y: self._to_training_input(x, y))\n",
-        "    ds = ds.filter(lambda x: tf.shape(x.input_tokens)[0] <= self._max_seq_len)\n",
-        "    ds = ds.batch(batch_size, drop_remainder=True)\n",
-        "    return ds"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "A3jRNKosyLUK"
-      },
-      "source": [
-        "Try the `MTNTDatasetBuilder` out by instantiating the custom `GemmaTokenizer` again, then applying it on the MTNT dataset, and sampling two examples:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {
-        "id": "bYeduOaNEcoZ"
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n",
-            "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n",
-            "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Example 0:\n",
-            "input_tokens: [[     2  49688    736   1280   6987 235292    108  10924    665  12302\n",
-            "  235341    108      2   4397  63011   1437  38696   1241      1      0]\n",
-            " [     2  49688    736   1280   6987 235292    108  13835   1517 235265\n",
-            "     108      2  69875    540  19713 235265      1      0      0      0]\n",
-            " [     2  49688    736   1280   6987 235292    108   6956   1586 235297\n",
-            "  235265    108      2  78368   1586 235297 235265      1      0      0]]\n",
-            "target_mask: [[False False False False False False False False False False False False\n",
-            "   True  True  True  True  True  True  True False]\n",
-            " [False False False False False False False False False False False  True\n",
-            "   True  True  True  True  True False False False]\n",
-            " [False False False False False False False False False False False False\n",
-            "   True  True  True  True  True  True False False]]\n",
-            "\n",
-            "Example 1:\n",
-            "input_tokens: [[     2  49688    736   1280   6987 235292    108  18874 235341    108\n",
-            "       2 115905   6425   1241      1      0      0      0      0      0]\n",
-            " [     2  49688    736   1280   6987 235292    108   7574   3356 235341\n",
-            "     108      2   7997  20707   1241      1      0      0      0      0]\n",
-            " [     2  49688    736   1280   6987 235292    108   8703    665 235265\n",
-            "     108      2 235338 235303  90006  20133 235265      1      0      0]]\n",
-            "target_mask: [[False False False False False False False False False False  True  True\n",
-            "   True  True  True False False False False False]\n",
-            " [False False False False False False False False False False False  True\n",
-            "   True  True  True  True False False False False]\n",
-            " [False False False False False False False False False False False  True\n",
-            "   True  True  True  True  True  True False False]]\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "tokenizer = GemmaTokenizer(vocab)\n",
-        "\n",
-        "dataset_builder = MTNTDatasetBuilder(tokenizer, max_seq_len=20)\n",
-        "ds = dataset_builder.get_train_dataset(3, 1)\n",
-        "ds = ds.take(2)\n",
-        "ds = ds.as_numpy_iterator()\n",
-        "\n",
-        "for idx, example in enumerate(ds):\n",
-        "  print(f'Example {idx}:')\n",
-        "  for key, val in example.items():\n",
-        "    print(f'{key}: {val}')\n",
-        "  print()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7IY8Muu1zRF4"
-      },
-      "source": [
-        "## Configure the model\n",
-        "\n",
-        "Before you begin fine-tuning the Gemma model, configure it as follows:\n",
-        "\n",
-        "Load and format the Gemma model checkpoint with the [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py) method:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "metadata": {
-        "id": "by6eWKtqzxRf"
-      },
-      "outputs": [],
-      "source": [
-        "params = params_lib.load_and_format_params(CKPT_PATH)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BtJhJkkZzsy1"
-      },
-      "source": [
-        "To automatically load the correct configuration from the Gemma model checkpoint, use [`gemma.transformer.TransformerConfig`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L65). The `cache_size` argument is the number of time steps in the Gemma `transformer` cache. Afterwards, instantiate the Gemma model as `transformer` with [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) (which inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html).\n",
-        "\n",
-        "**Note:** The vocabulary size is smaller than the number of input embeddings because of unused tokens in the current Gemma release."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {
-        "id": "_jjlFAkazzit"
-      },
-      "outputs": [],
-      "source": [
-        "config_2b = transformer_lib.TransformerConfig.from_params(\n",
-        "    params,\n",
-        "    cache_size=30\n",
-        ")\n",
-        "\n",
-        "model_2b = transformer_lib.Transformer(config=config_2b)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "t7UL2Af536x_"
-      },
-      "source": [
-        "## Fine-tune the model\n",
-        "\n",
-        "In this section, you will:\n",
-        "\n",
-        "- Use the `gemma.transformer.Transformer` class to create the forward pass and loss function.\n",
-        "- Build the position and attention mask vectors for tokens\n",
-        "- Build a training step function with Flax.\n",
-        "- Build the validation step without the backwards pass.\n",
-        "- Create the training loop.\n",
-        "- Fine-tune the Gemma model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aJhtJumH7H8_"
-      },
-      "source": [
-        "Define the forward pass and the loss function using the [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) class. The Gemma `Transformer` inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html), and offers two essential methods:\n",
-        "\n",
-        "- `init`: Initializes the model's parameters.\n",
-        "- `apply`: Executes the model's `__call__` function using a given set of parameters.\n",
-        "\n",
-        "  Since you are working with pre-trained Gemma weights, you don't need to use the `init` function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {
-        "id": "iEcV0XEEEcoZ"
-      },
-      "outputs": [],
-      "source": [
-        "def forward_and_loss_fn(params,\n",
-        "                        *,\n",
-        "                        model: transformer_lib.Transformer,\n",
-        "                        input_tokens: jax.Array,            # Shape [B, L]\n",
-        "                        input_mask: jax.Array,              # Shape [B, L]\n",
-        "                        positions: jax.Array,               # Shape [B, L]\n",
-        "                        attention_mask: jax.Array,          # [B, L, L]\n",
-        "                        ) -> jax.Array:\n",
-        "  \"\"\"The forward pass and the loss function.\n",
-        "\n",
-        "  Args:\n",
-        "    params: Model's input parameters.\n",
-        "    model: The Gemma transformer model to call.\n",
-        "    input_tokens: Input tokens sequence, shape [B, L].\n",
-        "    input_mask: Tokens to ignore when computing the loss, shape [B, L].\n",
-        "    positions: Relative position of each token, shape [B, L].\n",
-        "    attention_mask: Input attention mask, shape [B, L].\n",
-        "\n",
-        "  Returns:\n",
-        "    The softmax cross-entropy loss for the next-token prediction task.\n",
-        "  \"\"\"\n",
-        "\n",
-        "  # The forward pass on the input data.\n",
-        "  # No attention cache is needed here.\n",
-        "  logits, _ = model.apply(\n",
-        "        params,\n",
-        "        input_tokens,\n",
-        "        positions,\n",
-        "        None,              # Attention cache is None.\n",
-        "        attention_mask,\n",
-        "    )\n",
-        "\n",
-        "  # Exclude the last step as it does not appear in the targets.\n",
-        "  logits = logits[0, :-1]\n",
-        "\n",
-        "  # Similarly, the first token cannot be predicted.\n",
-        "  target_tokens = input_tokens[0, 1:]\n",
-        "  target_mask = input_mask[0, 1:]\n",
-        "\n",
-        "  # Convert the target labels to one-hot encoded vectors.\n",
-        "  one_hot = jax.nn.one_hot(target_tokens, logits.shape[-1])\n",
-        "\n",
-        "  # Don't update on unwanted tokens.\n",
-        "  one_hot = one_hot * target_mask.astype(one_hot.dtype)[...,None]\n",
-        "\n",
-        "  # Define the normalization factor.\n",
-        "  norm_factor = 1 / (jnp.sum(target_mask) + 1e-8)\n",
-        "\n",
-        "  # Return the negative log likelihood (NLL) loss.\n",
-        "  return -jnp.sum(jax.nn.log_softmax(logits) * one_hot) * norm_factor"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WxbxsKcd7Ot7"
-      },
-      "source": [
-        "The [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) class requires an `attention_mask` and a `positions` vector alongside each input. You can generate these by creating a custom function that uses [`Transformer.build_positions_from_mask`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L48) and [`Transformer.make_causal_attn_mask`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L29):\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 17,
-      "metadata": {
-        "id": "cbWfdHf0EcoZ"
-      },
-      "outputs": [],
-      "source": [
-        "def get_attention_mask_and_positions(example: jax.Array,\n",
-        "                                     pad_id : int,\n",
-        "                                     )-> tuple[jax.Array, jax.Array]:\n",
-        "  \"\"\"Builds the position and attention mask vectors from the given tokens.\"\"\"\n",
-        "  pad_mask = example != pad_id\n",
-        "  current_token_position = transformer_lib.build_positions_from_mask(pad_mask)\n",
-        "  attention_mask = transformer_lib.make_causal_attn_mask(pad_mask)\n",
-        "  return current_token_position, attention_mask"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "uRkeF6ed8tOI"
-      },
-      "source": [
-        "Build the `train_step` function that performs the backward pass and updates the model's parameters accordingly, where:\n",
-        "\n",
-        "- [`jax.value_and_grad`](https://jax.readthedocs.io/en/latest/_autosummary/jax.value_and_grad.html) is for evaluating the loss function and gradients during the forward and backward passes.\n",
-        "- [`optax.apply_updates`](https://optax.readthedocs.io/en/latest/api/apply_updates.html#optax.apply_updates) is for updating the parameters."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 18,
-      "metadata": {
-        "id": "cPSfp7ZUEcoZ"
-      },
-      "outputs": [],
-      "source": [
-        "def train_step(model: transformer_lib.Transformer,\n",
-        "               params,\n",
-        "               optimizer: optax.GradientTransformation,\n",
-        "               opt_state: optax.OptState,\n",
-        "               pad_id: int,\n",
-        "               example: TrainingInput):\n",
-        "  \"\"\"Train step.\n",
-        "\n",
-        "  Args:\n",
-        "    model: The Gemma transformer model.\n",
-        "    params: The model's input parameters.\n",
-        "    optimizer: The Optax optimizer to use.\n",
-        "    opt_state: The input optimizer's state.\n",
-        "    pad_id: ID of the pad token.\n",
-        "    example: Input batch.\n",
-        "\n",
-        "  Returns:\n",
-        "    The training loss, the updated parameters, and the updated optimizer state.\n",
-        "  \"\"\"\n",
-        "\n",
-        "  # Build the position and attention mask vectors.\n",
-        "  positions, attention_mask = get_attention_mask_and_positions(example.input_tokens, pad_id)\n",
-        "\n",
-        "  # The forward and backward passes.\n",
-        "  train_loss, grads = jax.value_and_grad(forward_and_loss_fn)(params,\n",
-        "                                                             model=model,\n",
-        "                                                             input_tokens=example.input_tokens,\n",
-        "                                                             input_mask=example.target_mask,\n",
-        "                                                             positions=positions,\n",
-        "                                                             attention_mask=attention_mask)\n",
-        "  # Update the parameters.\n",
-        "  updates, opt_state = optimizer.update(grads, opt_state)\n",
-        "  params = optax.apply_updates(params, updates)\n",
-        "\n",
-        "  return train_loss, params, opt_state"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8ZKSa-jJ809n"
-      },
-      "source": [
-        "Build the `validation_step` function without the backward pass:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 19,
-      "metadata": {
-        "id": "yU4oR92YEcoa"
-      },
-      "outputs": [],
-      "source": [
-        "def validation_step(model: transformer_lib.Transformer,\n",
-        "                    params,\n",
-        "                    pad_id: int,\n",
-        "                    example: TrainingInput,\n",
-        "                    ):\n",
-        "  positions, attention_mask = get_attention_mask_and_positions(example.input_tokens, pad_id)\n",
-        "  val_loss = forward_and_loss_fn(params,\n",
-        "                                 model=model,\n",
-        "                                 input_tokens=example.input_tokens,\n",
-        "                                 input_mask=example.target_mask,\n",
-        "                                 positions=positions,\n",
-        "                                 attention_mask=attention_mask)\n",
-        "  return val_loss"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bNqVhj7v87f4"
-      },
-      "source": [
-        "Define the training loop using [`optax.sgd`](https://optax.readthedocs.io/en/latest/api/optimizers.html#optax.sgd) for the SGD optimizer:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "metadata": {
-        "id": "xT4bAqNLEcoa"
-      },
-      "outputs": [],
-      "source": [
-        "@chex.dataclass(frozen=True)\n",
-        "class TrainingConfig:\n",
-        "  learning_rate: float\n",
-        "  num_epochs: int\n",
-        "  eval_every_n: int\n",
-        "  batch_size: int\n",
-        "  max_steps: int | None = None\n",
-        "\n",
-        "def train_loop(\n",
-        "    model: transformer_lib.Transformer,\n",
-        "    params,\n",
-        "    dataset_builder: MTNTDatasetBuilder,\n",
-        "    training_cfg: TrainingConfig):\n",
-        "\n",
-        "  # Apply `jax.jit` on the training step, making the whole loop much more efficient.\n",
-        "  compiled_train_step = jax.jit(train_step, static_argnames=['model', 'optimizer'])\n",
-        "\n",
-        "  # Apply `jax.jit` on the validation step.\n",
-        "  compiled_validation_step = jax.jit(validation_step, static_argnames=['model'])\n",
-        "\n",
-        "  # To save memory, use the SGD optimizer instead of the usual Adam optimizer.\n",
-        "  # Note that for this specific example, SGD is more than enough.\n",
-        "  optimizer = optax.sgd(training_cfg.learning_rate)\n",
-        "  opt_state = optimizer.init(params)\n",
-        "\n",
-        "  # Build the training dataset.\n",
-        "  train_ds = dataset_builder.get_train_dataset(batch_size=training_cfg.batch_size,\n",
-        "                                               num_epochs=training_cfg.num_epochs)\n",
-        "  train_ds = train_ds.as_numpy_iterator()\n",
-        "\n",
-        "  # Build the validation dataset, with a limited number of samples for this demo.\n",
-        "  validation_ds = dataset_builder.get_validation_dataset(batch_size=training_cfg.batch_size)\n",
-        "  validation_ds = validation_ds.take(50)\n",
-        "\n",
-        "  n_steps = 0\n",
-        "  avg_loss=0\n",
-        "\n",
-        "  # A first round of the validation loss.\n",
-        "  n_steps_eval = 0\n",
-        "  eval_loss = 0\n",
-        "  val_iterator = validation_ds.as_numpy_iterator()\n",
-        "  for val_example in val_iterator:\n",
-        "    eval_loss += compiled_validation_step(model,\n",
-        "                                          params,\n",
-        "                                          dataset_builder._tokenizer.pad_id,\n",
-        "                                          val_example)\n",
-        "    n_steps_eval += 1\n",
-        "  print(f\"Start, validation loss: {eval_loss/n_steps_eval}\")\n",
-        "\n",
-        "  for train_example in train_ds:\n",
-        "    train_loss, params, opt_state = compiled_train_step(model=model,\n",
-        "                                                        params=params,\n",
-        "                                                        optimizer=optimizer,\n",
-        "                                                        opt_state=opt_state,\n",
-        "                                                        pad_id=dataset_builder._tokenizer.pad_id,\n",
-        "                                                        example=train_example)\n",
-        "    n_steps += 1\n",
-        "    avg_loss += train_loss\n",
-        "    if n_steps % training_cfg.eval_every_n == 0:\n",
-        "      eval_loss = 0\n",
-        "\n",
-        "      n_steps_eval = 0\n",
-        "      val_iterator = validation_ds.as_numpy_iterator()\n",
-        "      for val_example in val_iterator:\n",
-        "        eval_loss += compiled_validation_step(model,\n",
-        "                                              params,\n",
-        "                                              dataset_builder._tokenizer.pad_id,\n",
-        "                                              val_example)\n",
-        "        n_steps_eval +=1\n",
-        "      avg_loss /= training_cfg.eval_every_n\n",
-        "      eval_loss /= n_steps_eval\n",
-        "      print(f\"STEP {n_steps} training loss: {avg_loss} - eval loss: {eval_loss}\")\n",
-        "      avg_loss=0\n",
-        "    if training_cfg.max_steps is not None and n_steps > training_cfg.max_steps:\n",
-        "      break\n",
-        "  return params"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ecv6lp5MCzFc"
-      },
-      "source": [
-        "Begin fine-tuning the Gemma model on a limited number of steps (`SEQ_SIZE`) to make sure this fits in the memory:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 21,
-      "metadata": {
-        "id": "7SL2VAmVEcoa"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Start, validation loss: 10.647212982177734\n",
-            "STEP 20 training loss: 3.3015992641448975 - eval loss: 2.686880111694336\n",
-            "STEP 40 training loss: 5.375057220458984 - eval loss: 2.6751961708068848\n",
-            "STEP 60 training loss: 2.6599338054656982 - eval loss: 2.663877010345459\n",
-            "STEP 80 training loss: 4.822389125823975 - eval loss: 2.3333375453948975\n",
-            "STEP 100 training loss: 2.0131142139434814 - eval loss: 2.360811948776245\n"
-          ]
-        }
-      ],
-      "source": [
-        "SEQ_SIZE = 25\n",
-        "tokenizer = GemmaTokenizer(vocab)\n",
-        "dataset_builder= MTNTDatasetBuilder(tokenizer, SEQ_SIZE)\n",
-        "training_cfg = TrainingConfig(learning_rate=1e-4,\n",
-        "                              num_epochs=1,\n",
-        "                              eval_every_n=20,\n",
-        "                              batch_size=1,\n",
-        "                              max_steps=100)\n",
-        "\n",
-        "params = train_loop(model=model_2b,\n",
-        "                    params={'params': params['transformer']},\n",
-        "                    dataset_builder=dataset_builder,\n",
-        "                    training_cfg=training_cfg)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EtfVo3pDDAZV"
-      },
-      "source": [
-        "Both the training loss and the validation loss should have gone down with each step count.\n",
-        "\n",
-        "Create a `sampler` with [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/sampler.py#L88). It uses the Gemma model checkpoint and the tokenizer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 22,
-      "metadata": {
-        "id": "dQ1oCF10Ecod"
-      },
-      "outputs": [],
-      "source": [
-        "sampler = sampler_lib.Sampler(\n",
-        "    transformer=model_2b,\n",
-        "    vocab=vocab,\n",
-        "    params=params['params'],\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-61KZz7EHiIS"
-      },
-      "source": [
-        "Use the `sampler` to check if your model can perform translation. The `total_generation_steps` argument in [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/sampler.py#L88) is the number of steps performed when generating a response. To ensure the input matches the training format, use the prefix `Translate this into French:\\n` with a newline character at the end. This signals the model to begin translation.\n",
-        "\n",
-        "**Note:** Due to hardware restrictions, the number of training parameters used in the gemma Transformer may not be sufficient to produce \"stable\" results in this demo.\n",
-        "\n",
-        "**Note:** If you run out of memory, click on **Runtime** > **Disconnect and delete runtime**, and then **Runtime** > **Run all**.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {
-        "id": "S5F3fk22Ecod"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "[\"C'est Bonjour, mon nom est Morgane.C'est Bonjour, mon nom est Morgane.\"]"
-            ]
-          },
-          "execution_count": 23,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "sampler(\n",
-        "    [\"Translate this into French:\\nHello, my name is Morgane.\\n\"],\n",
-        "    total_generation_steps=100,\n",
-        "    ).text"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Jao0Qk-ZIqyD"
-      },
-      "source": [
-        "## Learn more\n",
-        "\n",
-        "- You can learn more about the Google DeepMind [`gemma`  library on GitHub](https://github.com/google-deepmind/gemma), which contains docstrings of methods you used in this tutorial, such as [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py),\n",
-        "[`gemma.transformer`](https://github.com/google-deepmind/gemma/blob/main/gemma/transformer.py), and\n",
-        "[`gemma.sampler`](https://github.com/google-deepmind/gemma/blob/main/gemma/sampler.py).\n",
-        "- The following libraries have their own documentation sites: [core JAX](https://jax.readthedocs.io), [Flax](https://flax.readthedocs.io), [Chex](https://chex.readthedocs.io/en/latest/), [Optax](https://optax.readthedocs.io/en/latest/), and [Orbax](https://orbax.readthedocs.io/).\n",
-        "- For `sentencepiece` tokenizer/detokenizer documentation, check out [Google's `sentencepiece` GitHub repo](https://github.com/google/sentencepiece).\n",
-        "- For `kagglehub` documentation, check out `README.md` on [Kaggle's `kagglehub` GitHub repo](https://github.com/Kaggle/kagglehub).\n",
-        "- Learn how to [use Gemma models with Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/open-models/use-gemma).\n",
-        "- If you are using Google Cloud TPUs (v3-8 and newer), make sure to also update to the latest `jax[tpu]` package (`!pip install -U jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html`), restart the runtime, and check that `jax` and `jaxlib` versions match (`!pip list | grep jax`). This can prevent the `RuntimeError` that can arise because of the `jaxlib` and `jax` version mismatch. For more JAX installation instructions, refer to the [JAX docs](https://jax.readthedocs.io/en/latest/tutorials/installation.html#install-google-tpu)."
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "jax_finetune.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Tce3stUlHN0L"
+   },
+   "source": [
+    "##### Copyright 2024 Google LLC."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "id": "tuOe1ymfHZPu"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "N_yUpPhqrRrK"
+   },
+   "source": [
+    "# Fine-tuning Gemma using JAX and Flax"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-yDXE-RX835U"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/jax_finetune\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/google/generative-ai-docs/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://ai.google.dev/images/cloud-icon.svg\" width=\"40\" />Open in Vertex AI</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MUnQEMHBt3nc"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "Gemma is a family of lightweight, state-of-the-art open large language models, based on the Google DeepMind Gemini research and technology. This tutorial demonstrates how to fine-tune the Gemma 2B Instruct model for an English-French translation task using [Google DeepMind's `gemma` library](https://github.com/google-deepmind/gemma), [JAX](https://jax.readthedocs.io) (a high-performance numerical computing library), [Flax](https://flax.readthedocs.io) (the JAX-based neural network library), [Chex](https://chex.readthedocs.io/en/latest/) (a library of utilities for writing reliable JAX code), [Optax](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), and the [MTNT (Machine Translation of Noisy Text) dataset](https://arxiv.org/abs/1809.00388). Although Flax is not used directly in this notebook, Flax was used to create Gemma.\n",
+    "\n",
+    "The `gemma` library was written with JAX, Flax, [Orbax](https://orbax.readthedocs.io/) (a JAX-based library for training utilities like checkpointing), and [SentencePiece](https://github.com/google/sentencepiece) (a tokenizer/detokenizer library).\n",
+    "\n",
+    "**Note:** This notebook runs on A100 GPU in Google Colab. Free Colab hardware acceleration is *insufficient* to run this notebook, as it requires plenty of host memory, such as A100 GPU (available in Colab Pro) or at least Google Cloud TPU v3-8. You can use [a Kaggle VM notebook](https://www.kaggle.com/), which provides free TPU v3-8 acceleration; or [Google Cloud TPU](https://cloud.google.com/tpu?hl=en) offers TPU v3 and newer. Currently, Google Colab provides TPU v2, which is insufficient for this tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dbRLI7Q4-8Ve"
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "n8Ku4iK6PnC0"
+   },
+   "source": [
+    "### 1. Set up Kaggle access for Gemma\n",
+    "\n",
+    "To complete this tutorial, you first need to follow the setup instructions at [Gemma setup](https://ai.google.dev/gemma/docs/setup), which show you how to do the following:\n",
+    "\n",
+    "* Get access to Gemma on [kaggle.com](https://www.kaggle.com/models/google/gemma/).\n",
+    "* Select a Colab runtime with sufficient resources to run the Gemma model.\n",
+    "* Generate and configure a Kaggle username and API key.\n",
+    "\n",
+    "After you've completed the Gemma setup, move on to the next section, where you'll set environment variables for your Colab environment.\n",
+    "\n",
+    "### 2. Set environment variables\n",
+    "\n",
+    "Set environment variables for `KAGGLE_USERNAME` and `KAGGLE_KEY`. When prompted with the \"Grant access?\" messages, agree to provide secret access."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "AVH6Y4k2964n"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from google.colab import userdata # `userdata` is a Colab API.\n",
+    "\n",
+    "os.environ[\"KAGGLE_USERNAME\"] = userdata.get('KAGGLE_USERNAME')\n",
+    "os.environ[\"KAGGLE_KEY\"] = userdata.get('KAGGLE_KEY')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "m1UE1CEnE9ql"
+   },
+   "source": [
+    "### 3. Install the `gemma` library\n",
+    "\n",
+    "Free Colab hardware acceleration is currently *insufficient* to run this notebook. If you are using [Colab Pay As You Go or Colab Pro](https://colab.research.google.com/signup), click on **Edit** > **Notebook settings** > Select **A100 GPU** > **Save** to enable hardware acceleration.\n",
+    "\n",
+    "Next, you need to install the Google DeepMind `gemma` library from [`github.com/google-deepmind/gemma`](https://github.com/google-deepmind/gemma). If you get an error about \"pip's dependency resolver\", you can usually ignore it.\n",
+    "\n",
+    "**Note:** By installing `gemma`, you will also install [`flax`](https://flax.readthedocs.io), core [`jax`](https://jax.readthedocs.io), [`optax`](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), [`orbax`](https://orbax.readthedocs.io/), and [`sentencepiece`](https://github.com/google/sentencepiece)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "XpSw-_4EEcoY"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+      "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.7/133.7 kB\u001b[0m \u001b[31m1.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.4/244.4 kB\u001b[0m \u001b[31m5.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h  Building wheel for gemma (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "tensorflow-metadata 1.14.0 requires absl-py<2.0.0,>=0.9, but you have absl-py 2.1.0 which is incompatible.\u001b[0m\u001b[31m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install -q git+https://github.com/google-deepmind/gemma.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-mRkkT-iPYoq"
+   },
+   "source": [
+    "### 4. Import libraries\n",
+    "\n",
+    "This notebook uses [Flax](https://flax.readthedocs.io) (for neural networks), core [JAX](https://jax.readthedocs.io), [SentencePiece](https://github.com/google/sentencepiece) (for tokenization), [Chex](https://chex.readthedocs.io/en/latest/) (a library of utilities for writing reliable JAX code), and TensorFlow Datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "ChMf1H4mPVx_"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import enum\n",
+    "import re\n",
+    "import string\n",
+    "\n",
+    "import chex\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import optax\n",
+    "\n",
+    "import tensorflow as tf\n",
+    "import tensorflow_datasets as tfds\n",
+    "\n",
+    "from gemma import params as params_lib\n",
+    "from gemma import sampler as sampler_lib\n",
+    "from gemma import transformer as transformer_lib\n",
+    "import sentencepiece as spm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oNgKIkxMOsit"
+   },
+   "source": [
+    "## Load the Gemma model\n",
+    "\n",
+    "Load the Gemma model with [`kagglehub.model_download`](https://github.com/Kaggle/kagglehub/blob/bddefc718182282882b72f814d407d89e5d178c4/src/kagglehub/models.py#L12), which takes three arguments:\n",
+    "\n",
+    "- `handle`: The model handle from Kaggle\n",
+    "- `path`: (Optional string) The local path\n",
+    "- `force_download`: (Optional boolean) Forces to re-download the model\n",
+    "\n",
+    "**Note:** Be mindful that the `gemma-2b-it` model is around 3.7Gb in size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "X-i10429N-g2"
+   },
+   "outputs": [],
+   "source": [
+    "GEMMA_VARIANT = '2b-it' # @param ['2b', '2b-it'] {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "j_QdPAGyO5zl"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading from https://www.kaggle.com/api/v1/models/google/gemma/flax/2b-it/2/download...\n",
+      "100%|██████████| 3.67G/3.67G [00:26<00:00, 147MB/s]\n",
+      "Extracting model files...\n"
+     ]
+    }
+   ],
+   "source": [
+    "import kagglehub\n",
+    "\n",
+    "GEMMA_PATH = kagglehub.model_download(f'google/gemma/flax/{GEMMA_VARIANT}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "cjnXlLkWcHIy"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GEMMA_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('GEMMA_PATH:', GEMMA_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "E1HzOpDcM04q"
+   },
+   "source": [
+    "**Note:** The path from the output above is where the model weights and tokenizer are saved locally, you will need them for later."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6ytvcJ8FPEMm"
+   },
+   "source": [
+    "Check the location of the model weights and the tokenizer, then set the path variables. The tokenizer directory will be in the main directory where you downloaded the model, while the model weights will be in a sub-directory. For example:\n",
+    "\n",
+    "- The `tokenizer.model` file will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2`).\n",
+    "- The model checkpoint will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2/2b-it`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "JAwXvpzbuiB5"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CKPT_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/2b-it\n",
+      "TOKENIZER_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/tokenizer.model\n"
+     ]
+    }
+   ],
+   "source": [
+    "CKPT_PATH = os.path.join(GEMMA_PATH, GEMMA_VARIANT)\n",
+    "TOKENIZER_PATH = os.path.join(GEMMA_PATH, 'tokenizer.model')\n",
+    "print('CKPT_PATH:', CKPT_PATH)\n",
+    "print('TOKENIZER_PATH:', TOKENIZER_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "U800JRcJVIlF"
+   },
+   "source": [
+    "## Load and prepare the MTNT dataset and the Gemma tokenizer\n",
+    "\n",
+    "You will use the [MTNT (Machine Translation of Noisy Text)](https://arxiv.org/abs/1809.00388) dataset, which is available from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/mtnt).\n",
+    "\n",
+    "Download the English-to-French dataset portion of the MTNT dataset, and then sample two examples. Each sample in the dataset contains two entries: `src`: the original English sentence; and `dst`: the corresponding French translation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "pg8SfQH0EcoY"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading and preparing dataset 35.08 MiB (download: 35.08 MiB, generated: 11.33 MiB, total: 46.41 MiB) to /root/tensorflow_datasets/mtnt/en-fr/1.0.0...\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4ec9a4a2b77f41e4a7435359338b140c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Dl Completed...: 0 url [00:00, ? url/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f799eec281194b80b8f260224df50ae3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Dl Size...: 0 MiB [00:00, ? MiB/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4804ce26e0b84a5e8a9774bb5dcd1ebc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Extraction completed...: 0 file [00:00, ? file/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "04b3ecfe7275446e816804c01da57572",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating splits...:   0%|          | 0/3 [00:00<?, ? splits/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8e2b3d7109ea47a4a28bf02f0683c50b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating train examples...:   0%|          | 0/35692 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "da26bf08c7be4a79b64e94b3f5ad028c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-train.tfrecord*...:   0%|          …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c864366a50e94b4fbc38085f0f602dca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating test examples...:   0%|          | 0/1020 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ad5ce2585efc45899da7b33ac0663005",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-test.tfrecord*...:   0%|          |…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "384b494a52a54757ab3fdefee721327c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating valid examples...:   0%|          | 0/811 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "943840b94fc64a05baf9c8e057dc3b85",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-valid.tfrecord*...:   0%|          …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset mtnt downloaded and prepared to /root/tensorflow_datasets/mtnt/en-fr/1.0.0. Subsequent calls will reuse this data.\n",
+      "Example 0:\n",
+      "dst: b'Le groupe de \" toutes les \\xc3\\xa9toiles potentielles de la conf\\xc3\\xa9rence de l\\'Est mais qui ne s\\'en sortent pas dans le groupe de l\\'Ouest \".'\n",
+      "src: b'The group of \\xe2\\x80\\x9ceastern conference potential all stars but not making it in the West\\xe2\\x80\\x9d group.'\n",
+      "\n",
+      "Example 1:\n",
+      "dst: b\"Kameron est-elle un peu aigrie de son manque de temps \\xc3\\xa0 l'\\xc3\\xa9cran ?\"\n",
+      "src: b'Is Kameron a Little Salty About Her Lack of Air Time?'\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "ds = tfds.load(\"mtnt/en-fr\", split=\"train\")\n",
+    "\n",
+    "ds = ds.take(2)\n",
+    "ds = ds.as_numpy_iterator()\n",
+    "\n",
+    "for idx, example in enumerate(ds):\n",
+    "  print(f'Example {idx}:')\n",
+    "  for key, val in example.items():\n",
+    "    print(f'{key}: {val}')\n",
+    "  print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XlY3EYV6jXWR"
+   },
+   "source": [
+    "Load the Gemma tokenizer, constructed using [`sentencepiece.SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "TpyG5YW1EcoY"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vocab = spm.SentencePieceProcessor()\n",
+    "vocab.Load(TOKENIZER_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Mk_CV0A1kR4K"
+   },
+   "source": [
+    "Customize the[`SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423) for the English-to-French translation task. Since you will be fine-tuning the English portion of the Gemma model, you need to make a few adjustments, such as:\n",
+    "\n",
+    "- *The input prefix*: Adding a common prefix to each input signals the translation task. For example, you could use a prompt with a prefix like `Translate this into French: [INPUT_SENTENCE]`.\n",
+    "\n",
+    "- *The translation start suffix*: Adding a suffix at the end of each prompt instructs the Gemma model exactly when to begin the translation process. A new line should do the job.\n",
+    "\n",
+    "- *Language model tokens*: Gemma models expect a \"beginning of sequence\" token at the beginning of each sequence, so adding an \"end of sequence\" token at the end of each training example should be sufficient.\n",
+    "\n",
+    "  Build a custom wrapper around the `SentencePieceProcessor` as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "L9cjK0uxEcoY"
+   },
+   "outputs": [],
+   "source": [
+    "class GemmaTokenizer:\n",
+    "\n",
+    "  def __init__(self,\n",
+    "               spm_processor: spm.SentencePieceProcessor):\n",
+    "    self._spm_processor = spm_processor\n",
+    "\n",
+    "  @property\n",
+    "  def pad_id(self) -> int:\n",
+    "    \"\"\"Fast access to the pad ID.\"\"\"\n",
+    "    return self._spm_processor.pad_id()\n",
+    "\n",
+    "  def tokenize(self,\n",
+    "               example: str | bytes,\n",
+    "               prefix: str = '',\n",
+    "               suffix: str = '',\n",
+    "               add_eos: bool = True) -> jax.Array:\n",
+    "    \"\"\"\n",
+    "    The tokenization function.\n",
+    "\n",
+    "    Args:\n",
+    "      example: Input string to tokenize.\n",
+    "      prefix:  Prefix to add to the input string.\n",
+    "      suffix:  Suffix to add to the input string.\n",
+    "      add_eos: If True, add an \"end of sentence\" token at the end of the output\n",
+    "               sequence.\n",
+    "    Returns:\n",
+    "      Tokens corresponding to the input string.\n",
+    "    \"\"\"\n",
+    "    int_list = [self._spm_processor.bos_id()]\n",
+    "    int_list.extend(self._spm_processor.EncodeAsIds(prefix + example + suffix))\n",
+    "    if add_eos:\n",
+    "      int_list.append(self._spm_processor.eos_id())\n",
+    "\n",
+    "    return jnp.array(int_list, dtype=jnp.int32)\n",
+    "\n",
+    "  def tokenize_tf_op(self,\n",
+    "                     str_tensor: tf.Tensor,\n",
+    "                     prefix: str = '',\n",
+    "                     suffix: str = '',\n",
+    "                     add_eos: bool = True) -> tf.Tensor:\n",
+    "    \"\"\"A TensorFlow operator for the tokenize function.\"\"\"\n",
+    "    encoded = tf.numpy_function(\n",
+    "        self.tokenize,\n",
+    "        [str_tensor, prefix, suffix, add_eos],\n",
+    "        tf.int32)\n",
+    "    encoded.set_shape([None])\n",
+    "    return encoded\n",
+    "\n",
+    "  def to_string(self, tokens: jax.Array) -> str:\n",
+    "    \"\"\"Convert an array of tokens to a string.\"\"\"\n",
+    "    return self._spm_processor.EncodeIds(tokens.tolist())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h-oJ2ziwxG1L"
+   },
+   "source": [
+    "Try it out by instantiating your new custom `GemmaTokenizer`, and then applying it on a small sample of the MTNT dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "id": "xEA-97ioEcoY"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Example 0:\n",
+      "src: [     2  49688    736   1280   6987 235292    108    651   2778    576\n",
+      "   1080 104745  11982   5736    832   8995    901    780   3547    665\n",
+      "    575    573   4589 235369   2778 235265    108]\n",
+      "dst: [     2   2025  29653    581    664  16298   1437  55563  41435   7840\n",
+      "    581    683 111452    581    533 235303   9776   4108   2459    679\n",
+      "    485 235303    479   6728    579   1806   2499    709  29653    581\n",
+      "    533 235303 101323  16054      1]\n",
+      "\n",
+      "Example 1:\n",
+      "src: [     2  49688    736   1280   6987 235292    108   2437  87150    477\n",
+      "    476  11709 230461   8045   3636  40268    576   4252   4897 235336\n",
+      "    108]\n",
+      "dst: [     2 213606    477   1455 235290   3510    748   8268 191017   2809\n",
+      "    581   2032  69972    581  11495   1305    533 235303  65978   1654\n",
+      "      1]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "tokenizer = GemmaTokenizer(vocab)\n",
+    "\n",
+    "def tokenize_source(tokenizer, example: tf.Tensor):\n",
+    "  return tokenizer.tokenize_tf_op(example,\n",
+    "                                  prefix='Translate this into French:\\n',\n",
+    "                                  suffix='\\n',\n",
+    "                                  add_eos=False)\n",
+    "def tokenize_destination(tokenizer, example: tf.Tensor):\n",
+    "  return tokenizer.tokenize_tf_op(example,\n",
+    "                                  add_eos=True)\n",
+    "\n",
+    "ds = tfds.load(\"mtnt/en-fr\",split=\"train\")\n",
+    "ds = ds.take(2)\n",
+    "ds = ds.map(lambda x: {'src': tokenize_source(tokenizer, x['src']),\n",
+    "                       'dst': tokenize_destination(tokenizer, x['dst'])})\n",
+    "ds = ds.as_numpy_iterator()\n",
+    "\n",
+    "for idx, example in enumerate(ds):\n",
+    "  print(f'Example {idx}:')\n",
+    "  for key, val in example.items():\n",
+    "    print(f'{key}: {val}')\n",
+    "  print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qkY_hThVkkqF"
+   },
+   "source": [
+    "Build a data loader for the entire MTNT dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "id": "Zm30Q2lnknmG"
+   },
+   "outputs": [],
+   "source": [
+    "@chex.dataclass(frozen=True)\n",
+    "class TrainingInput:\n",
+    "  # Input tokens provided to the model.\n",
+    "  input_tokens: jax.Array\n",
+    "\n",
+    "  # A mask that determines which tokens contribute to the target loss\n",
+    "  # calculation.\n",
+    "  target_mask: jax.Array\n",
+    "\n",
+    "class DatasetSplit(enum.Enum):\n",
+    "  TRAIN = 'train'\n",
+    "  VALIDATION = 'valid'\n",
+    "\n",
+    "class MTNTDatasetBuilder:\n",
+    "  \"\"\"The dataset builder for the MTNT dataset.\"\"\"\n",
+    "\n",
+    "  N_ITEMS = {DatasetSplit.TRAIN: 35_692,\n",
+    "             DatasetSplit.VALIDATION: 811}\n",
+    "\n",
+    "  BUFFER_SIZE_SHUFFLE = 10_000\n",
+    "  TRANSLATION_PREFIX = 'Translate this into French:\\n'\n",
+    "  TRANSLATION_SUFFIX = '\\n'\n",
+    "\n",
+    "  def __init__(self,\n",
+    "               tokenizer : GemmaTokenizer,\n",
+    "               max_seq_len: int):\n",
+    "    \"\"\"Constructor.\n",
+    "\n",
+    "    Args:\n",
+    "      tokenizer: Gemma tokenizer to use.\n",
+    "      max_seq_len: size of each sequence in a given batch.\n",
+    "    \"\"\"\n",
+    "    self._tokenizer = tokenizer\n",
+    "    self._base_data = {\n",
+    "        DatasetSplit.TRAIN: tfds.load(\"mtnt/en-fr\",split=\"train\"),\n",
+    "        DatasetSplit.VALIDATION: tfds.load(\"mtnt/en-fr\",split=\"valid\"),\n",
+    "    }\n",
+    "    self._max_seq_len = max_seq_len\n",
+    "\n",
+    "  def _tokenize_source(self, example: tf.Tensor):\n",
+    "    \"\"\"Tokenization function for the source.\"\"\"\n",
+    "    return self._tokenizer.tokenize_tf_op(example,\n",
+    "                                          prefix=self.TRANSLATION_PREFIX,\n",
+    "                                          suffix=self.TRANSLATION_SUFFIX,\n",
+    "                                          add_eos=False)\n",
+    "\n",
+    "  def _tokenize_destination(self, example: tf.Tensor):\n",
+    "    \"\"\"Tokenization function for the French translation.\"\"\"\n",
+    "    return self._tokenizer.tokenize_tf_op(example,\n",
+    "                                          add_eos=True)\n",
+    "\n",
+    "  def _pad_up_to_max_len(self,\n",
+    "                         input_tensor: tf.Tensor,\n",
+    "                         pad_value: int | bool,\n",
+    "                         ) -> tf.Tensor:\n",
+    "    \"\"\"Pad the given tensor up to sequence length of a batch.\"\"\"\n",
+    "    seq_len = tf.shape(input_tensor)[0]\n",
+    "    to_pad = tf.maximum(self._max_seq_len - seq_len, 0)\n",
+    "    return tf.pad(input_tensor,\n",
+    "                  [[0, to_pad]],\n",
+    "                  mode='CONSTANT',\n",
+    "                  constant_values=pad_value,\n",
+    "                  )\n",
+    "\n",
+    "  def _to_training_input(self,\n",
+    "                         src_tokens: jax.Array,\n",
+    "                         dst_tokens: jax.Array,\n",
+    "                         ) -> TrainingInput:\n",
+    "    \"\"\"Build a training input from a tuple of source and destination tokens.\"\"\"\n",
+    "\n",
+    "    # The input sequence fed to the model is simply the concatenation of the\n",
+    "    # source and the destination.\n",
+    "    tokens = tf.concat([src_tokens, dst_tokens], axis=0)\n",
+    "\n",
+    "    # To prevent the model from updating based on the source (input)\n",
+    "    # tokens, add a target mask to each input.\n",
+    "    q_mask = tf.zeros_like(src_tokens, dtype=tf.bool)\n",
+    "    a_mask = tf.ones_like(dst_tokens, dtype=tf.bool)\n",
+    "    mask = tf.concat([q_mask, a_mask], axis=0)\n",
+    "\n",
+    "    # If the output tokens sequence is smaller than the target sequence size,\n",
+    "    # then pad it with pad tokens.\n",
+    "    tokens = self._pad_up_to_max_len(tokens, self._tokenizer.pad_id)\n",
+    "\n",
+    "    # Don't want to perform the backward pass on the pad tokens.\n",
+    "    mask = self._pad_up_to_max_len(mask, False)\n",
+    "\n",
+    "    return TrainingInput(input_tokens=tokens, target_mask=mask)\n",
+    "\n",
+    "\n",
+    "  def get_train_dataset(self, batch_size: int, num_epochs: int):\n",
+    "    \"\"\"Build the training dataset.\"\"\"\n",
+    "\n",
+    "    # Tokenize each sample.\n",
+    "    ds = self._base_data[DatasetSplit.TRAIN].map(lambda x : (self._tokenize_source(x['src']),\n",
+    "                                                             self._tokenize_destination(x['dst'])))\n",
+    "\n",
+    "    # Convert the samples to training inputs.\n",
+    "    ds = ds.map(lambda x, y: self._to_training_input(x, y))\n",
+    "\n",
+    "    # Remove the samples that are too long.\n",
+    "    ds = ds.filter(lambda x: tf.shape(x.input_tokens)[0] <= self._max_seq_len)\n",
+    "\n",
+    "    # Shuffle the dataset.\n",
+    "    ds = ds.shuffle(buffer_size=self.BUFFER_SIZE_SHUFFLE)\n",
+    "\n",
+    "    # Repeat if necessary.\n",
+    "    ds = ds.repeat(num_epochs)\n",
+    "\n",
+    "    # Build batches.\n",
+    "    ds = ds.batch(batch_size, drop_remainder=True)\n",
+    "    return ds\n",
+    "\n",
+    "  def get_validation_dataset(self, batch_size: int):\n",
+    "    \"\"\"Build the validation dataset.\"\"\"\n",
+    "\n",
+    "    # Same steps as in `get_train_dataset`, but without shuffling and no repetition.\n",
+    "    ds = self._base_data[DatasetSplit.VALIDATION].map(lambda x : (self._tokenize_source(x['src']),\n",
+    "                                                                  self._tokenize_destination(x['dst'])))\n",
+    "    ds = ds.map(lambda x, y: self._to_training_input(x, y))\n",
+    "    ds = ds.filter(lambda x: tf.shape(x.input_tokens)[0] <= self._max_seq_len)\n",
+    "    ds = ds.batch(batch_size, drop_remainder=True)\n",
+    "    return ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "A3jRNKosyLUK"
+   },
+   "source": [
+    "Try the `MTNTDatasetBuilder` out by instantiating the custom `GemmaTokenizer` again, then applying it on the MTNT dataset, and sampling two examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "id": "bYeduOaNEcoZ"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n",
+      "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n",
+      "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Example 0:\n",
+      "input_tokens: [[     2  49688    736   1280   6987 235292    108  10924    665  12302\n",
+      "  235341    108      2   4397  63011   1437  38696   1241      1      0]\n",
+      " [     2  49688    736   1280   6987 235292    108  13835   1517 235265\n",
+      "     108      2  69875    540  19713 235265      1      0      0      0]\n",
+      " [     2  49688    736   1280   6987 235292    108   6956   1586 235297\n",
+      "  235265    108      2  78368   1586 235297 235265      1      0      0]]\n",
+      "target_mask: [[False False False False False False False False False False False False\n",
+      "   True  True  True  True  True  True  True False]\n",
+      " [False False False False False False False False False False False  True\n",
+      "   True  True  True  True  True False False False]\n",
+      " [False False False False False False False False False False False False\n",
+      "   True  True  True  True  True  True False False]]\n",
+      "\n",
+      "Example 1:\n",
+      "input_tokens: [[     2  49688    736   1280   6987 235292    108  18874 235341    108\n",
+      "       2 115905   6425   1241      1      0      0      0      0      0]\n",
+      " [     2  49688    736   1280   6987 235292    108   7574   3356 235341\n",
+      "     108      2   7997  20707   1241      1      0      0      0      0]\n",
+      " [     2  49688    736   1280   6987 235292    108   8703    665 235265\n",
+      "     108      2 235338 235303  90006  20133 235265      1      0      0]]\n",
+      "target_mask: [[False False False False False False False False False False  True  True\n",
+      "   True  True  True False False False False False]\n",
+      " [False False False False False False False False False False False  True\n",
+      "   True  True  True  True False False False False]\n",
+      " [False False False False False False False False False False False  True\n",
+      "   True  True  True  True  True  True False False]]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "tokenizer = GemmaTokenizer(vocab)\n",
+    "\n",
+    "dataset_builder = MTNTDatasetBuilder(tokenizer, max_seq_len=20)\n",
+    "ds = dataset_builder.get_train_dataset(3, 1)\n",
+    "ds = ds.take(2)\n",
+    "ds = ds.as_numpy_iterator()\n",
+    "\n",
+    "for idx, example in enumerate(ds):\n",
+    "  print(f'Example {idx}:')\n",
+    "  for key, val in example.items():\n",
+    "    print(f'{key}: {val}')\n",
+    "  print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7IY8Muu1zRF4"
+   },
+   "source": [
+    "## Configure the model\n",
+    "\n",
+    "Before you begin fine-tuning the Gemma model, you need to configure it.\n",
+    "\n",
+    "First, load and format the Gemma model checkpoint with the [`gemma.params.load_and_format_params`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/params.py#L27) method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "id": "by6eWKtqzxRf"
+   },
+   "outputs": [],
+   "source": [
+    "params = params_lib.load_and_format_params(CKPT_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BtJhJkkZzsy1"
+   },
+   "source": [
+    "To automatically load the correct configuration from the Gemma model checkpoint, use [`gemma.transformer.TransformerConfig`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L65). The `cache_size` argument is the number of time steps in the Gemma `Transformer` cache. Afterwards, instantiate the Gemma model as `model_2b` with [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) (which inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html)).\n",
+    "\n",
+    "**Note:** The vocabulary size is smaller than the number of input embeddings because of unused tokens in the current Gemma release."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "id": "_jjlFAkazzit"
+   },
+   "outputs": [],
+   "source": [
+    "config_2b = transformer_lib.TransformerConfig.from_params(\n",
+    "    params,\n",
+    "    cache_size=30\n",
+    ")\n",
+    "\n",
+    "model_2b = transformer_lib.Transformer(config=config_2b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "t7UL2Af536x_"
+   },
+   "source": [
+    "## Fine-tune the model\n",
+    "\n",
+    "In this section, you will:\n",
+    "\n",
+    "- Use the `gemma.transformer.Transformer` class to create the forward pass and loss function.\n",
+    "- Build the position and attention mask vectors for tokens\n",
+    "- Build a training step function with Flax.\n",
+    "- Build the validation step without the backwards pass.\n",
+    "- Create the training loop.\n",
+    "- Fine-tune the Gemma model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aJhtJumH7H8_"
+   },
+   "source": [
+    "Define the forward pass and the loss function using the [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) class. The Gemma `Transformer` inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html), and offers two essential methods:\n",
+    "\n",
+    "- `init`: Initializes the model's parameters.\n",
+    "- `apply`: Executes the model's `__call__` function using a given set of parameters.\n",
+    "\n",
+    "  Since you are working with pre-trained Gemma weights, you don't need to use the `init` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "id": "iEcV0XEEEcoZ"
+   },
+   "outputs": [],
+   "source": [
+    "def forward_and_loss_fn(params,\n",
+    "                        *,\n",
+    "                        model: transformer_lib.Transformer,\n",
+    "                        input_tokens: jax.Array,            # Shape [B, L]\n",
+    "                        input_mask: jax.Array,              # Shape [B, L]\n",
+    "                        positions: jax.Array,               # Shape [B, L]\n",
+    "                        attention_mask: jax.Array,          # [B, L, L]\n",
+    "                        ) -> jax.Array:\n",
+    "  \"\"\"The forward pass and the loss function.\n",
+    "\n",
+    "  Args:\n",
+    "    params: Model's input parameters.\n",
+    "    model: The Gemma transformer model to call.\n",
+    "    input_tokens: Input tokens sequence, shape [B, L].\n",
+    "    input_mask: Tokens to ignore when computing the loss, shape [B, L].\n",
+    "    positions: Relative position of each token, shape [B, L].\n",
+    "    attention_mask: Input attention mask, shape [B, L].\n",
+    "\n",
+    "  Returns:\n",
+    "    The softmax cross-entropy loss for the next-token prediction task.\n",
+    "  \"\"\"\n",
+    "\n",
+    "  # The forward pass on the input data.\n",
+    "  # No attention cache is needed here.\n",
+    "  logits, _ = model.apply(\n",
+    "        params,\n",
+    "        input_tokens,\n",
+    "        positions,\n",
+    "        None,              # Attention cache is None.\n",
+    "        attention_mask,\n",
+    "    )\n",
+    "\n",
+    "  # Exclude the last step as it does not appear in the targets.\n",
+    "  logits = logits[0, :-1]\n",
+    "\n",
+    "  # Similarly, the first token cannot be predicted.\n",
+    "  target_tokens = input_tokens[0, 1:]\n",
+    "  target_mask = input_mask[0, 1:]\n",
+    "\n",
+    "  # Convert the target labels to one-hot encoded vectors.\n",
+    "  one_hot = jax.nn.one_hot(target_tokens, logits.shape[-1])\n",
+    "\n",
+    "  # Don't update on unwanted tokens.\n",
+    "  one_hot = one_hot * target_mask.astype(one_hot.dtype)[...,None]\n",
+    "\n",
+    "  # Define the normalization factor.\n",
+    "  norm_factor = 1 / (jnp.sum(target_mask) + 1e-8)\n",
+    "\n",
+    "  # Return the negative log likelihood (NLL) loss.\n",
+    "  return -jnp.sum(jax.nn.log_softmax(logits) * one_hot) * norm_factor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WxbxsKcd7Ot7"
+   },
+   "source": [
+    "The [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) class requires an `attention_mask` and a `positions` vector alongside each input. You can generate these by creating a custom function that uses [`Transformer.build_positions_from_mask`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L48) and [`Transformer.make_causal_attn_mask`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L29):\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "id": "cbWfdHf0EcoZ"
+   },
+   "outputs": [],
+   "source": [
+    "def get_attention_mask_and_positions(example: jax.Array,\n",
+    "                                     pad_id : int,\n",
+    "                                     )-> tuple[jax.Array, jax.Array]:\n",
+    "  \"\"\"Builds the position and attention mask vectors from the given tokens.\"\"\"\n",
+    "  pad_mask = example != pad_id\n",
+    "  current_token_position = transformer_lib.build_positions_from_mask(pad_mask)\n",
+    "  attention_mask = transformer_lib.make_causal_attn_mask(pad_mask)\n",
+    "  return current_token_position, attention_mask"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "uRkeF6ed8tOI"
+   },
+   "source": [
+    "Build the `train_step` function that performs the backward pass and updates the model's parameters accordingly, where:\n",
+    "\n",
+    "- [`jax.value_and_grad`](https://jax.readthedocs.io/en/latest/_autosummary/jax.value_and_grad.html) is for evaluating the loss function and gradients during the forward and backward passes.\n",
+    "- [`optax.apply_updates`](https://optax.readthedocs.io/en/latest/api/apply_updates.html#optax.apply_updates) is for updating the parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "id": "cPSfp7ZUEcoZ"
+   },
+   "outputs": [],
+   "source": [
+    "def train_step(model: transformer_lib.Transformer,\n",
+    "               params,\n",
+    "               optimizer: optax.GradientTransformation,\n",
+    "               opt_state: optax.OptState,\n",
+    "               pad_id: int,\n",
+    "               example: TrainingInput):\n",
+    "  \"\"\"Train step.\n",
+    "\n",
+    "  Args:\n",
+    "    model: The Gemma transformer model.\n",
+    "    params: The model's input parameters.\n",
+    "    optimizer: The Optax optimizer to use.\n",
+    "    opt_state: The input optimizer's state.\n",
+    "    pad_id: ID of the pad token.\n",
+    "    example: Input batch.\n",
+    "\n",
+    "  Returns:\n",
+    "    The training loss, the updated parameters, and the updated optimizer state.\n",
+    "  \"\"\"\n",
+    "\n",
+    "  # Build the position and attention mask vectors.\n",
+    "  positions, attention_mask = get_attention_mask_and_positions(example.input_tokens, pad_id)\n",
+    "\n",
+    "  # The forward and backward passes.\n",
+    "  train_loss, grads = jax.value_and_grad(forward_and_loss_fn)(params,\n",
+    "                                                             model=model,\n",
+    "                                                             input_tokens=example.input_tokens,\n",
+    "                                                             input_mask=example.target_mask,\n",
+    "                                                             positions=positions,\n",
+    "                                                             attention_mask=attention_mask)\n",
+    "  # Update the parameters.\n",
+    "  updates, opt_state = optimizer.update(grads, opt_state)\n",
+    "  params = optax.apply_updates(params, updates)\n",
+    "\n",
+    "  return train_loss, params, opt_state"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8ZKSa-jJ809n"
+   },
+   "source": [
+    "Build the `validation_step` function without the backward pass:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "id": "yU4oR92YEcoa"
+   },
+   "outputs": [],
+   "source": [
+    "def validation_step(model: transformer_lib.Transformer,\n",
+    "                    params,\n",
+    "                    pad_id: int,\n",
+    "                    example: TrainingInput,\n",
+    "                    ):\n",
+    "  positions, attention_mask = get_attention_mask_and_positions(example.input_tokens, pad_id)\n",
+    "  val_loss = forward_and_loss_fn(params,\n",
+    "                                 model=model,\n",
+    "                                 input_tokens=example.input_tokens,\n",
+    "                                 input_mask=example.target_mask,\n",
+    "                                 positions=positions,\n",
+    "                                 attention_mask=attention_mask)\n",
+    "  return val_loss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bNqVhj7v87f4"
+   },
+   "source": [
+    "Define the training loop using [`optax.sgd`](https://optax.readthedocs.io/en/latest/api/optimizers.html#optax.sgd) for the SGD optimizer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "id": "xT4bAqNLEcoa"
+   },
+   "outputs": [],
+   "source": [
+    "@chex.dataclass(frozen=True)\n",
+    "class TrainingConfig:\n",
+    "  learning_rate: float\n",
+    "  num_epochs: int\n",
+    "  eval_every_n: int\n",
+    "  batch_size: int\n",
+    "  max_steps: int | None = None\n",
+    "\n",
+    "def train_loop(\n",
+    "    model: transformer_lib.Transformer,\n",
+    "    params,\n",
+    "    dataset_builder: MTNTDatasetBuilder,\n",
+    "    training_cfg: TrainingConfig):\n",
+    "\n",
+    "  # Apply `jax.jit` on the training step, making the whole loop much more efficient.\n",
+    "  compiled_train_step = jax.jit(train_step, static_argnames=['model', 'optimizer'])\n",
+    "\n",
+    "  # Apply `jax.jit` on the validation step.\n",
+    "  compiled_validation_step = jax.jit(validation_step, static_argnames=['model'])\n",
+    "\n",
+    "  # To save memory, use the SGD optimizer instead of the usual Adam optimizer.\n",
+    "  # Note that for this specific example, SGD is more than enough.\n",
+    "  optimizer = optax.sgd(training_cfg.learning_rate)\n",
+    "  opt_state = optimizer.init(params)\n",
+    "\n",
+    "  # Build the training dataset.\n",
+    "  train_ds = dataset_builder.get_train_dataset(batch_size=training_cfg.batch_size,\n",
+    "                                               num_epochs=training_cfg.num_epochs)\n",
+    "  train_ds = train_ds.as_numpy_iterator()\n",
+    "\n",
+    "  # Build the validation dataset, with a limited number of samples for this demo.\n",
+    "  validation_ds = dataset_builder.get_validation_dataset(batch_size=training_cfg.batch_size)\n",
+    "  validation_ds = validation_ds.take(50)\n",
+    "\n",
+    "  n_steps = 0\n",
+    "  avg_loss=0\n",
+    "\n",
+    "  # A first round of the validation loss.\n",
+    "  n_steps_eval = 0\n",
+    "  eval_loss = 0\n",
+    "  val_iterator = validation_ds.as_numpy_iterator()\n",
+    "  for val_example in val_iterator:\n",
+    "    eval_loss += compiled_validation_step(model,\n",
+    "                                          params,\n",
+    "                                          dataset_builder._tokenizer.pad_id,\n",
+    "                                          val_example)\n",
+    "    n_steps_eval += 1\n",
+    "  print(f\"Start, validation loss: {eval_loss/n_steps_eval}\")\n",
+    "\n",
+    "  for train_example in train_ds:\n",
+    "    train_loss, params, opt_state = compiled_train_step(model=model,\n",
+    "                                                        params=params,\n",
+    "                                                        optimizer=optimizer,\n",
+    "                                                        opt_state=opt_state,\n",
+    "                                                        pad_id=dataset_builder._tokenizer.pad_id,\n",
+    "                                                        example=train_example)\n",
+    "    n_steps += 1\n",
+    "    avg_loss += train_loss\n",
+    "    if n_steps % training_cfg.eval_every_n == 0:\n",
+    "      eval_loss = 0\n",
+    "\n",
+    "      n_steps_eval = 0\n",
+    "      val_iterator = validation_ds.as_numpy_iterator()\n",
+    "      for val_example in val_iterator:\n",
+    "        eval_loss += compiled_validation_step(model,\n",
+    "                                              params,\n",
+    "                                              dataset_builder._tokenizer.pad_id,\n",
+    "                                              val_example)\n",
+    "        n_steps_eval +=1\n",
+    "      avg_loss /= training_cfg.eval_every_n\n",
+    "      eval_loss /= n_steps_eval\n",
+    "      print(f\"STEP {n_steps} training loss: {avg_loss} - eval loss: {eval_loss}\")\n",
+    "      avg_loss=0\n",
+    "    if training_cfg.max_steps is not None and n_steps > training_cfg.max_steps:\n",
+    "      break\n",
+    "  return params"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ecv6lp5MCzFc"
+   },
+   "source": [
+    "Begin fine-tuning the Gemma model on a limited number of steps (`SEQ_SIZE`) to make sure this fits in the memory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "id": "7SL2VAmVEcoa"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Start, validation loss: 10.647212982177734\n",
+      "STEP 20 training loss: 3.3015992641448975 - eval loss: 2.686880111694336\n",
+      "STEP 40 training loss: 5.375057220458984 - eval loss: 2.6751961708068848\n",
+      "STEP 60 training loss: 2.6599338054656982 - eval loss: 2.663877010345459\n",
+      "STEP 80 training loss: 4.822389125823975 - eval loss: 2.3333375453948975\n",
+      "STEP 100 training loss: 2.0131142139434814 - eval loss: 2.360811948776245\n"
+     ]
+    }
+   ],
+   "source": [
+    "SEQ_SIZE = 25\n",
+    "tokenizer = GemmaTokenizer(vocab)\n",
+    "dataset_builder= MTNTDatasetBuilder(tokenizer, SEQ_SIZE)\n",
+    "training_cfg = TrainingConfig(learning_rate=1e-4,\n",
+    "                              num_epochs=1,\n",
+    "                              eval_every_n=20,\n",
+    "                              batch_size=1,\n",
+    "                              max_steps=100)\n",
+    "\n",
+    "params = train_loop(model=model_2b,\n",
+    "                    params={'params': params['transformer']},\n",
+    "                    dataset_builder=dataset_builder,\n",
+    "                    training_cfg=training_cfg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EtfVo3pDDAZV"
+   },
+   "source": [
+    "Both the training loss and the validation loss should have gone down with each step count.\n",
+    "\n",
+    "Create a `sampler` with [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/sampler.py#L88). It uses the Gemma model checkpoint and the tokenizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "id": "dQ1oCF10Ecod"
+   },
+   "outputs": [],
+   "source": [
+    "sampler = sampler_lib.Sampler(\n",
+    "    transformer=model_2b,\n",
+    "    vocab=vocab,\n",
+    "    params=params['params'],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-61KZz7EHiIS"
+   },
+   "source": [
+    "Use the `sampler` to check if your model can perform translation. The `total_generation_steps` argument in [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/sampler.py#L88) is the number of steps performed when generating a response. To ensure the input matches the training format, use the prefix `Translate this into French:\\n` with a newline character at the end. This signals the model to begin translation.\n",
+    "\n",
+    "**Note:** Due to hardware restrictions, the number of training parameters used in the gemma Transformer may not be sufficient to produce \"stable\" results in this demo.\n",
+    "\n",
+    "**Note:** If you run out of memory, click on **Runtime** > **Disconnect and delete runtime**, and then **Runtime** > **Run all**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "id": "S5F3fk22Ecod"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[\"C'est Bonjour, mon nom est Morgane.C'est Bonjour, mon nom est Morgane.\"]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sampler(\n",
+    "    [\"Translate this into French:\\nHello, my name is Morgane.\\n\"],\n",
+    "    total_generation_steps=100,\n",
+    "    ).text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Jao0Qk-ZIqyD"
+   },
+   "source": [
+    "## Learn more\n",
+    "\n",
+    "- You can learn more about the Google DeepMind [`gemma`  library on GitHub](https://github.com/google-deepmind/gemma), which contains docstrings of modules you used in this tutorial, such as [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py),\n",
+    "[`gemma.transformer`](https://github.com/google-deepmind/gemma/blob/main/gemma/transformer.py), and\n",
+    "[`gemma.sampler`](https://github.com/google-deepmind/gemma/blob/main/gemma/sampler.py).\n",
+    "- The following libraries have their own documentation sites: [core JAX](https://jax.readthedocs.io), [Flax](https://flax.readthedocs.io), [Chex](https://chex.readthedocs.io/en/latest/), [Optax](https://optax.readthedocs.io/en/latest/), and [Orbax](https://orbax.readthedocs.io/).\n",
+    "- For `sentencepiece` tokenizer/detokenizer documentation, check out [Google's `sentencepiece` GitHub repo](https://github.com/google/sentencepiece).\n",
+    "- For `kagglehub` documentation, check out `README.md` on [Kaggle's `kagglehub` GitHub repo](https://github.com/Kaggle/kagglehub).\n",
+    "- Learn how to [use Gemma models with Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/open-models/use-gemma).\n",
+    "- If you are using Google Cloud TPUs (v3-8 and newer), make sure to also update to the latest `jax[tpu]` package (`!pip install -U jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html`), restart the runtime, and check that `jax` and `jaxlib` versions match (`!pip list | grep jax`). This can prevent the `RuntimeError` that can arise because of the `jaxlib` and `jax` version mismatch. For more JAX installation instructions, refer to the [JAX docs](https://jax.readthedocs.io/en/latest/tutorials/installation.html#install-google-tpu)."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "name": "jax_finetune.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/site/en/gemma/docs/jax_finetune.ipynb
+++ b/site/en/gemma/docs/jax_finetune.ipynb
@@ -1,1415 +1,1402 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Tce3stUlHN0L"
-   },
-   "source": [
-    "##### Copyright 2024 Google LLC."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "cellView": "form",
-    "id": "tuOe1ymfHZPu"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "N_yUpPhqrRrK"
-   },
-   "source": [
-    "# Fine-tuning Gemma using JAX and Flax"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-yDXE-RX835U"
-   },
-   "source": [
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/jax_finetune\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/google/generative-ai-docs/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://ai.google.dev/images/cloud-icon.svg\" width=\"40\" />Open in Vertex AI</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "MUnQEMHBt3nc"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "Gemma is a family of lightweight, state-of-the-art open large language models, based on the Google DeepMind Gemini research and technology. This tutorial demonstrates how to fine-tune the Gemma 2B Instruct model for an English-French translation task using [Google DeepMind's `gemma` library](https://github.com/google-deepmind/gemma), [JAX](https://jax.readthedocs.io) (a high-performance numerical computing library), [Flax](https://flax.readthedocs.io) (the JAX-based neural network library), [Chex](https://chex.readthedocs.io/en/latest/) (a library of utilities for writing reliable JAX code), [Optax](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), and the [MTNT (Machine Translation of Noisy Text) dataset](https://arxiv.org/abs/1809.00388). Although Flax is not used directly in this notebook, Flax was used to create Gemma.\n",
-    "\n",
-    "The `gemma` library was written with JAX, Flax, [Orbax](https://orbax.readthedocs.io/) (a JAX-based library for training utilities like checkpointing), and [SentencePiece](https://github.com/google/sentencepiece) (a tokenizer/detokenizer library).\n",
-    "\n",
-    "**Note:** This notebook runs on A100 GPU in Google Colab. Free Colab hardware acceleration is *insufficient* to run this notebook, as it requires plenty of host memory, such as A100 GPU (available in Colab Pro) or at least Google Cloud TPU v3-8. You can use [a Kaggle VM notebook](https://www.kaggle.com/), which provides free TPU v3-8 acceleration; or [Google Cloud TPU](https://cloud.google.com/tpu?hl=en) offers TPU v3 and newer. Currently, Google Colab provides TPU v2, which is insufficient for this tutorial."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dbRLI7Q4-8Ve"
-   },
-   "source": [
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "n8Ku4iK6PnC0"
-   },
-   "source": [
-    "### 1. Set up Kaggle access for Gemma\n",
-    "\n",
-    "To complete this tutorial, you first need to follow the setup instructions at [Gemma setup](https://ai.google.dev/gemma/docs/setup), which show you how to do the following:\n",
-    "\n",
-    "* Get access to Gemma on [kaggle.com](https://www.kaggle.com/models/google/gemma/).\n",
-    "* Select a Colab runtime with sufficient resources to run the Gemma model.\n",
-    "* Generate and configure a Kaggle username and API key.\n",
-    "\n",
-    "After you've completed the Gemma setup, move on to the next section, where you'll set environment variables for your Colab environment.\n",
-    "\n",
-    "### 2. Set environment variables\n",
-    "\n",
-    "Set environment variables for `KAGGLE_USERNAME` and `KAGGLE_KEY`. When prompted with the \"Grant access?\" messages, agree to provide secret access."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "id": "AVH6Y4k2964n"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from google.colab import userdata # `userdata` is a Colab API.\n",
-    "\n",
-    "os.environ[\"KAGGLE_USERNAME\"] = userdata.get('KAGGLE_USERNAME')\n",
-    "os.environ[\"KAGGLE_KEY\"] = userdata.get('KAGGLE_KEY')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "m1UE1CEnE9ql"
-   },
-   "source": [
-    "### 3. Install the `gemma` library\n",
-    "\n",
-    "Free Colab hardware acceleration is currently *insufficient* to run this notebook. If you are using [Colab Pay As You Go or Colab Pro](https://colab.research.google.com/signup), click on **Edit** > **Notebook settings** > Select **A100 GPU** > **Save** to enable hardware acceleration.\n",
-    "\n",
-    "Next, you need to install the Google DeepMind `gemma` library from [`github.com/google-deepmind/gemma`](https://github.com/google-deepmind/gemma). If you get an error about \"pip's dependency resolver\", you can usually ignore it.\n",
-    "\n",
-    "**Note:** By installing `gemma`, you will also install [`flax`](https://flax.readthedocs.io), core [`jax`](https://jax.readthedocs.io), [`optax`](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), [`orbax`](https://orbax.readthedocs.io/), and [`sentencepiece`](https://github.com/google/sentencepiece)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "id": "XpSw-_4EEcoY"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
-      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
-      "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.7/133.7 kB\u001b[0m \u001b[31m1.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.4/244.4 kB\u001b[0m \u001b[31m5.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h  Building wheel for gemma (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "tensorflow-metadata 1.14.0 requires absl-py<2.0.0,>=0.9, but you have absl-py 2.1.0 which is incompatible.\u001b[0m\u001b[31m\n",
-      "\u001b[0m"
-     ]
-    }
-   ],
-   "source": [
-    "!pip install -q git+https://github.com/google-deepmind/gemma.git"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-mRkkT-iPYoq"
-   },
-   "source": [
-    "### 4. Import libraries\n",
-    "\n",
-    "This notebook uses [Flax](https://flax.readthedocs.io) (for neural networks), core [JAX](https://jax.readthedocs.io), [SentencePiece](https://github.com/google/sentencepiece) (for tokenization), [Chex](https://chex.readthedocs.io/en/latest/) (a library of utilities for writing reliable JAX code), and TensorFlow Datasets."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "ChMf1H4mPVx_"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import enum\n",
-    "import re\n",
-    "import string\n",
-    "\n",
-    "import chex\n",
-    "import jax\n",
-    "import jax.numpy as jnp\n",
-    "import optax\n",
-    "\n",
-    "import tensorflow as tf\n",
-    "import tensorflow_datasets as tfds\n",
-    "\n",
-    "from gemma import params as params_lib\n",
-    "from gemma import sampler as sampler_lib\n",
-    "from gemma import transformer as transformer_lib\n",
-    "import sentencepiece as spm"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "oNgKIkxMOsit"
-   },
-   "source": [
-    "## Load the Gemma model\n",
-    "\n",
-    "Load the Gemma model with [`kagglehub.model_download`](https://github.com/Kaggle/kagglehub/blob/bddefc718182282882b72f814d407d89e5d178c4/src/kagglehub/models.py#L12), which takes three arguments:\n",
-    "\n",
-    "- `handle`: The model handle from Kaggle\n",
-    "- `path`: (Optional string) The local path\n",
-    "- `force_download`: (Optional boolean) Forces to re-download the model\n",
-    "\n",
-    "**Note:** Be mindful that the `gemma-2b-it` model is around 3.7Gb in size."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "id": "X-i10429N-g2"
-   },
-   "outputs": [],
-   "source": [
-    "GEMMA_VARIANT = '2b-it' # @param ['2b', '2b-it'] {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "id": "j_QdPAGyO5zl"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Downloading from https://www.kaggle.com/api/v1/models/google/gemma/flax/2b-it/2/download...\n",
-      "100%|██████████| 3.67G/3.67G [00:26<00:00, 147MB/s]\n",
-      "Extracting model files...\n"
-     ]
-    }
-   ],
-   "source": [
-    "import kagglehub\n",
-    "\n",
-    "GEMMA_PATH = kagglehub.model_download(f'google/gemma/flax/{GEMMA_VARIANT}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "id": "cjnXlLkWcHIy"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GEMMA_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2\n"
-     ]
-    }
-   ],
-   "source": [
-    "print('GEMMA_PATH:', GEMMA_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "E1HzOpDcM04q"
-   },
-   "source": [
-    "**Note:** The path from the output above is where the model weights and tokenizer are saved locally, you will need them for later."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "6ytvcJ8FPEMm"
-   },
-   "source": [
-    "Check the location of the model weights and the tokenizer, then set the path variables. The tokenizer directory will be in the main directory where you downloaded the model, while the model weights will be in a sub-directory. For example:\n",
-    "\n",
-    "- The `tokenizer.model` file will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2`).\n",
-    "- The model checkpoint will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2/2b-it`)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "id": "JAwXvpzbuiB5"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CKPT_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/2b-it\n",
-      "TOKENIZER_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/tokenizer.model\n"
-     ]
-    }
-   ],
-   "source": [
-    "CKPT_PATH = os.path.join(GEMMA_PATH, GEMMA_VARIANT)\n",
-    "TOKENIZER_PATH = os.path.join(GEMMA_PATH, 'tokenizer.model')\n",
-    "print('CKPT_PATH:', CKPT_PATH)\n",
-    "print('TOKENIZER_PATH:', TOKENIZER_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "U800JRcJVIlF"
-   },
-   "source": [
-    "## Load and prepare the MTNT dataset and the Gemma tokenizer\n",
-    "\n",
-    "You will use the [MTNT (Machine Translation of Noisy Text)](https://arxiv.org/abs/1809.00388) dataset, which is available from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/mtnt).\n",
-    "\n",
-    "Download the English-to-French dataset portion of the MTNT dataset, and then sample two examples. Each sample in the dataset contains two entries: `src`: the original English sentence; and `dst`: the corresponding French translation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "id": "pg8SfQH0EcoY"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading and preparing dataset 35.08 MiB (download: 35.08 MiB, generated: 11.33 MiB, total: 46.41 MiB) to /root/tensorflow_datasets/mtnt/en-fr/1.0.0...\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4ec9a4a2b77f41e4a7435359338b140c",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Tce3stUlHN0L"
       },
-      "text/plain": [
-       "Dl Completed...: 0 url [00:00, ? url/s]"
+      "source": [
+        "##### Copyright 2024 Google LLC."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f799eec281194b80b8f260224df50ae3",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "tuOe1ymfHZPu"
       },
-      "text/plain": [
-       "Dl Size...: 0 MiB [00:00, ? MiB/s]"
+      "outputs": [],
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4804ce26e0b84a5e8a9774bb5dcd1ebc",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "N_yUpPhqrRrK"
       },
-      "text/plain": [
-       "Extraction completed...: 0 file [00:00, ? file/s]"
+      "source": [
+        "# Fine-tuning Gemma using JAX and Flax"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04b3ecfe7275446e816804c01da57572",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-yDXE-RX835U"
       },
-      "text/plain": [
-       "Generating splits...:   0%|          | 0/3 [00:00<?, ? splits/s]"
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/jax_finetune\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/google/generative-ai-docs/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://ai.google.dev/images/cloud-icon.svg\" width=\"40\" />Open in Vertex AI</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_finetune.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8e2b3d7109ea47a4a28bf02f0683c50b",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MUnQEMHBt3nc"
       },
-      "text/plain": [
-       "Generating train examples...:   0%|          | 0/35692 [00:00<?, ? examples/s]"
+      "source": [
+        "## Overview\n",
+        "\n",
+        "Gemma is a family of lightweight, state-of-the-art open large language models, based on the Google DeepMind Gemini research and technology. This tutorial demonstrates how to fine-tune the Gemma 2B Instruct model for an English-French translation task using [Google DeepMind's `gemma` library](https://github.com/google-deepmind/gemma), [JAX](https://jax.readthedocs.io) (a high-performance numerical computing library), [Flax](https://flax.readthedocs.io) (the JAX-based neural network library), [Chex](https://chex.readthedocs.io/en/latest/) (a library of utilities for writing reliable JAX code), [Optax](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), and the [MTNT (Machine Translation of Noisy Text) dataset](https://arxiv.org/abs/1809.00388). Although Flax is not used directly in this notebook, Flax was used to create Gemma.\n",
+        "\n",
+        "The `gemma` library was written with JAX, Flax, [Orbax](https://orbax.readthedocs.io/) (a JAX-based library for training utilities like checkpointing), and [SentencePiece](https://github.com/google/sentencepiece) (a tokenizer/detokenizer library).\n",
+        "\n",
+        "**Note:** This notebook runs on A100 GPU in Google Colab. Free Colab hardware acceleration is *insufficient* to run this notebook, as it requires plenty of host memory, such as A100 GPU (available in Colab Pro) or at least Google Cloud TPU v3-8. You can use [a Kaggle VM notebook](https://www.kaggle.com/), which provides free TPU v3-8 acceleration; or [Google Cloud TPU](https://cloud.google.com/tpu?hl=en) offers TPU v3 and newer. Currently, Google Colab provides TPU v2, which is insufficient for this tutorial."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da26bf08c7be4a79b64e94b3f5ad028c",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dbRLI7Q4-8Ve"
       },
-      "text/plain": [
-       "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-train.tfrecord*...:   0%|          …"
+      "source": [
+        "## Setup"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c864366a50e94b4fbc38085f0f602dca",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "n8Ku4iK6PnC0"
       },
-      "text/plain": [
-       "Generating test examples...:   0%|          | 0/1020 [00:00<?, ? examples/s]"
+      "source": [
+        "### 1. Set up Kaggle access for Gemma\n",
+        "\n",
+        "To complete this tutorial, you first need to follow the setup instructions at [Gemma setup](https://ai.google.dev/gemma/docs/setup), which show you how to do the following:\n",
+        "\n",
+        "* Get access to Gemma on [kaggle.com](https://www.kaggle.com/models/google/gemma/).\n",
+        "* Select a Colab runtime with sufficient resources to run the Gemma model.\n",
+        "* Generate and configure a Kaggle username and API key.\n",
+        "\n",
+        "After you've completed the Gemma setup, move on to the next section, where you'll set environment variables for your Colab environment.\n",
+        "\n",
+        "### 2. Set environment variables\n",
+        "\n",
+        "Set environment variables for `KAGGLE_USERNAME` and `KAGGLE_KEY`. When prompted with the \"Grant access?\" messages, agree to provide secret access."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ad5ce2585efc45899da7b33ac0663005",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "AVH6Y4k2964n"
       },
-      "text/plain": [
-       "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-test.tfrecord*...:   0%|          |…"
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from google.colab import userdata # `userdata` is a Colab API.\n",
+        "\n",
+        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get('KAGGLE_USERNAME')\n",
+        "os.environ[\"KAGGLE_KEY\"] = userdata.get('KAGGLE_KEY')"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "384b494a52a54757ab3fdefee721327c",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "m1UE1CEnE9ql"
       },
-      "text/plain": [
-       "Generating valid examples...:   0%|          | 0/811 [00:00<?, ? examples/s]"
+      "source": [
+        "### 3. Install the `gemma` library\n",
+        "\n",
+        "Free Colab hardware acceleration is currently *insufficient* to run this notebook. If you are using [Colab Pay As You Go or Colab Pro](https://colab.research.google.com/signup), click on **Edit** > **Notebook settings** > Select **A100 GPU** > **Save** to enable hardware acceleration.\n",
+        "\n",
+        "Next, you need to install the Google DeepMind `gemma` library from [`github.com/google-deepmind/gemma`](https://github.com/google-deepmind/gemma). If you get an error about \"pip's dependency resolver\", you can usually ignore it.\n",
+        "\n",
+        "**Note:** By installing `gemma`, you will also install [`flax`](https://flax.readthedocs.io), core [`jax`](https://jax.readthedocs.io), [`optax`](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), [`orbax`](https://orbax.readthedocs.io/), and [`sentencepiece`](https://github.com/google/sentencepiece)."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "943840b94fc64a05baf9c8e057dc3b85",
-       "version_major": 2,
-       "version_minor": 0
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "XpSw-_4EEcoY"
       },
-      "text/plain": [
-       "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-valid.tfrecord*...:   0%|          …"
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.7/133.7 kB\u001b[0m \u001b[31m1.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.4/244.4 kB\u001b[0m \u001b[31m5.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Building wheel for gemma (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "tensorflow-metadata 1.14.0 requires absl-py<2.0.0,>=0.9, but you have absl-py 2.1.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0m"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install -q git+https://github.com/google-deepmind/gemma.git"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset mtnt downloaded and prepared to /root/tensorflow_datasets/mtnt/en-fr/1.0.0. Subsequent calls will reuse this data.\n",
-      "Example 0:\n",
-      "dst: b'Le groupe de \" toutes les \\xc3\\xa9toiles potentielles de la conf\\xc3\\xa9rence de l\\'Est mais qui ne s\\'en sortent pas dans le groupe de l\\'Ouest \".'\n",
-      "src: b'The group of \\xe2\\x80\\x9ceastern conference potential all stars but not making it in the West\\xe2\\x80\\x9d group.'\n",
-      "\n",
-      "Example 1:\n",
-      "dst: b\"Kameron est-elle un peu aigrie de son manque de temps \\xc3\\xa0 l'\\xc3\\xa9cran ?\"\n",
-      "src: b'Is Kameron a Little Salty About Her Lack of Air Time?'\n",
-      "\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-mRkkT-iPYoq"
+      },
+      "source": [
+        "### 4. Import libraries\n",
+        "\n",
+        "This notebook uses [Flax](https://flax.readthedocs.io) (for neural networks), core [JAX](https://jax.readthedocs.io), [SentencePiece](https://github.com/google/sentencepiece) (for tokenization), [Chex](https://chex.readthedocs.io/en/latest/) (a library of utilities for writing reliable JAX code), and TensorFlow Datasets."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "ChMf1H4mPVx_"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import enum\n",
+        "import re\n",
+        "import string\n",
+        "\n",
+        "import chex\n",
+        "import jax\n",
+        "import jax.numpy as jnp\n",
+        "import optax\n",
+        "\n",
+        "import tensorflow as tf\n",
+        "import tensorflow_datasets as tfds\n",
+        "\n",
+        "from gemma import params as params_lib\n",
+        "from gemma import sampler as sampler_lib\n",
+        "from gemma import transformer as transformer_lib\n",
+        "import sentencepiece as spm"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oNgKIkxMOsit"
+      },
+      "source": [
+        "## Load the Gemma model\n",
+        "\n",
+        "Load the Gemma model with [`kagglehub.model_download`](https://github.com/Kaggle/kagglehub/blob/bddefc718182282882b72f814d407d89e5d178c4/src/kagglehub/models.py#L12), which takes three arguments:\n",
+        "\n",
+        "- `handle`: The model handle from Kaggle\n",
+        "- `path`: (Optional string) The local path\n",
+        "- `force_download`: (Optional boolean) Forces to re-download the model\n",
+        "\n",
+        "**Note:** Be mindful that the `gemma-2b-it` model is around 3.7Gb in size."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "X-i10429N-g2"
+      },
+      "outputs": [],
+      "source": [
+        "GEMMA_VARIANT = '2b-it' # @param ['2b', '2b-it'] {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "j_QdPAGyO5zl"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Downloading from https://www.kaggle.com/api/v1/models/google/gemma/flax/2b-it/2/download...\n",
+            "100%|██████████| 3.67G/3.67G [00:26<00:00, 147MB/s]\n",
+            "Extracting model files...\n"
+          ]
+        }
+      ],
+      "source": [
+        "import kagglehub\n",
+        "\n",
+        "GEMMA_PATH = kagglehub.model_download(f'google/gemma/flax/{GEMMA_VARIANT}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "cjnXlLkWcHIy"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "GEMMA_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2\n"
+          ]
+        }
+      ],
+      "source": [
+        "print('GEMMA_PATH:', GEMMA_PATH)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "E1HzOpDcM04q"
+      },
+      "source": [
+        "**Note:** The path from the output above is where the model weights and tokenizer are saved locally, you will need them for later."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "6ytvcJ8FPEMm"
+      },
+      "source": [
+        "Check the location of the model weights and the tokenizer, then set the path variables. The tokenizer directory will be in the main directory where you downloaded the model, while the model weights will be in a sub-directory. For example:\n",
+        "\n",
+        "- The `tokenizer.model` file will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2`).\n",
+        "- The model checkpoint will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2/2b-it`)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "JAwXvpzbuiB5"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "CKPT_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/2b-it\n",
+            "TOKENIZER_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/tokenizer.model\n"
+          ]
+        }
+      ],
+      "source": [
+        "CKPT_PATH = os.path.join(GEMMA_PATH, GEMMA_VARIANT)\n",
+        "TOKENIZER_PATH = os.path.join(GEMMA_PATH, 'tokenizer.model')\n",
+        "print('CKPT_PATH:', CKPT_PATH)\n",
+        "print('TOKENIZER_PATH:', TOKENIZER_PATH)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "U800JRcJVIlF"
+      },
+      "source": [
+        "## Load and prepare the MTNT dataset and the Gemma tokenizer\n",
+        "\n",
+        "You will use the [MTNT (Machine Translation of Noisy Text)](https://arxiv.org/abs/1809.00388) dataset, which is available from [TensorFlow Datasets](https://www.tensorflow.org/datasets/catalog/mtnt).\n",
+        "\n",
+        "Download the English-to-French dataset portion of the MTNT dataset, and then sample two examples. Each sample in the dataset contains two entries: `src`: the original English sentence; and `dst`: the corresponding French translation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "pg8SfQH0EcoY"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Downloading and preparing dataset 35.08 MiB (download: 35.08 MiB, generated: 11.33 MiB, total: 46.41 MiB) to /root/tensorflow_datasets/mtnt/en-fr/1.0.0...\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "4ec9a4a2b77f41e4a7435359338b140c",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Dl Completed...: 0 url [00:00, ? url/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "f799eec281194b80b8f260224df50ae3",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Dl Size...: 0 MiB [00:00, ? MiB/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "4804ce26e0b84a5e8a9774bb5dcd1ebc",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Extraction completed...: 0 file [00:00, ? file/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "04b3ecfe7275446e816804c01da57572",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Generating splits...:   0%|          | 0/3 [00:00<?, ? splits/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "8e2b3d7109ea47a4a28bf02f0683c50b",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Generating train examples...:   0%|          | 0/35692 [00:00<?, ? examples/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "da26bf08c7be4a79b64e94b3f5ad028c",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-train.tfrecord*...:   0%|          …"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "c864366a50e94b4fbc38085f0f602dca",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Generating test examples...:   0%|          | 0/1020 [00:00<?, ? examples/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "ad5ce2585efc45899da7b33ac0663005",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-test.tfrecord*...:   0%|          |…"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "384b494a52a54757ab3fdefee721327c",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Generating valid examples...:   0%|          | 0/811 [00:00<?, ? examples/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "943840b94fc64a05baf9c8e057dc3b85",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Shuffling /root/tensorflow_datasets/mtnt/en-fr/1.0.0.incomplete6YJMND/mtnt-valid.tfrecord*...:   0%|          …"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Dataset mtnt downloaded and prepared to /root/tensorflow_datasets/mtnt/en-fr/1.0.0. Subsequent calls will reuse this data.\n",
+            "Example 0:\n",
+            "dst: b'Le groupe de \" toutes les \\xc3\\xa9toiles potentielles de la conf\\xc3\\xa9rence de l\\'Est mais qui ne s\\'en sortent pas dans le groupe de l\\'Ouest \".'\n",
+            "src: b'The group of \\xe2\\x80\\x9ceastern conference potential all stars but not making it in the West\\xe2\\x80\\x9d group.'\n",
+            "\n",
+            "Example 1:\n",
+            "dst: b\"Kameron est-elle un peu aigrie de son manque de temps \\xc3\\xa0 l'\\xc3\\xa9cran ?\"\n",
+            "src: b'Is Kameron a Little Salty About Her Lack of Air Time?'\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "ds = tfds.load(\"mtnt/en-fr\", split=\"train\")\n",
+        "\n",
+        "ds = ds.take(2)\n",
+        "ds = ds.as_numpy_iterator()\n",
+        "\n",
+        "for idx, example in enumerate(ds):\n",
+        "  print(f'Example {idx}:')\n",
+        "  for key, val in example.items():\n",
+        "    print(f'{key}: {val}')\n",
+        "  print()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XlY3EYV6jXWR"
+      },
+      "source": [
+        "Load the Gemma tokenizer, constructed using [`sentencepiece.SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "TpyG5YW1EcoY"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "execution_count": 9,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "vocab = spm.SentencePieceProcessor()\n",
+        "vocab.Load(TOKENIZER_PATH)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Mk_CV0A1kR4K"
+      },
+      "source": [
+        "Customize the[`SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423) for the English-to-French translation task. Since you will be fine-tuning the English portion of the Gemma model, you need to make a few adjustments, such as:\n",
+        "\n",
+        "- *The input prefix*: Adding a common prefix to each input signals the translation task. For example, you could use a prompt with a prefix like `Translate this into French: [INPUT_SENTENCE]`.\n",
+        "\n",
+        "- *The translation start suffix*: Adding a suffix at the end of each prompt instructs the Gemma model exactly when to begin the translation process. A new line should do the job.\n",
+        "\n",
+        "- *Language model tokens*: Gemma models expect a \"beginning of sequence\" token at the beginning of each sequence, so adding an \"end of sequence\" token at the end of each training example should be sufficient.\n",
+        "\n",
+        "  Build a custom wrapper around the `SentencePieceProcessor` as follows:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "L9cjK0uxEcoY"
+      },
+      "outputs": [],
+      "source": [
+        "class GemmaTokenizer:\n",
+        "\n",
+        "  def __init__(self,\n",
+        "               spm_processor: spm.SentencePieceProcessor):\n",
+        "    self._spm_processor = spm_processor\n",
+        "\n",
+        "  @property\n",
+        "  def pad_id(self) -> int:\n",
+        "    \"\"\"Fast access to the pad ID.\"\"\"\n",
+        "    return self._spm_processor.pad_id()\n",
+        "\n",
+        "  def tokenize(self,\n",
+        "               example: str | bytes,\n",
+        "               prefix: str = '',\n",
+        "               suffix: str = '',\n",
+        "               add_eos: bool = True) -> jax.Array:\n",
+        "    \"\"\"\n",
+        "    The tokenization function.\n",
+        "\n",
+        "    Args:\n",
+        "      example: Input string to tokenize.\n",
+        "      prefix:  Prefix to add to the input string.\n",
+        "      suffix:  Suffix to add to the input string.\n",
+        "      add_eos: If True, add an \"end of sentence\" token at the end of the output\n",
+        "               sequence.\n",
+        "    Returns:\n",
+        "      Tokens corresponding to the input string.\n",
+        "    \"\"\"\n",
+        "    int_list = [self._spm_processor.bos_id()]\n",
+        "    int_list.extend(self._spm_processor.EncodeAsIds(prefix + example + suffix))\n",
+        "    if add_eos:\n",
+        "      int_list.append(self._spm_processor.eos_id())\n",
+        "\n",
+        "    return jnp.array(int_list, dtype=jnp.int32)\n",
+        "\n",
+        "  def tokenize_tf_op(self,\n",
+        "                     str_tensor: tf.Tensor,\n",
+        "                     prefix: str = '',\n",
+        "                     suffix: str = '',\n",
+        "                     add_eos: bool = True) -> tf.Tensor:\n",
+        "    \"\"\"A TensorFlow operator for the tokenize function.\"\"\"\n",
+        "    encoded = tf.numpy_function(\n",
+        "        self.tokenize,\n",
+        "        [str_tensor, prefix, suffix, add_eos],\n",
+        "        tf.int32)\n",
+        "    encoded.set_shape([None])\n",
+        "    return encoded\n",
+        "\n",
+        "  def to_string(self, tokens: jax.Array) -> str:\n",
+        "    \"\"\"Convert an array of tokens to a string.\"\"\"\n",
+        "    return self._spm_processor.EncodeIds(tokens.tolist())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "h-oJ2ziwxG1L"
+      },
+      "source": [
+        "Try it out by instantiating your new custom `GemmaTokenizer`, and then applying it on a small sample of the MTNT dataset:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "id": "xEA-97ioEcoY"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Example 0:\n",
+            "src: [     2  49688    736   1280   6987 235292    108    651   2778    576\n",
+            "   1080 104745  11982   5736    832   8995    901    780   3547    665\n",
+            "    575    573   4589 235369   2778 235265    108]\n",
+            "dst: [     2   2025  29653    581    664  16298   1437  55563  41435   7840\n",
+            "    581    683 111452    581    533 235303   9776   4108   2459    679\n",
+            "    485 235303    479   6728    579   1806   2499    709  29653    581\n",
+            "    533 235303 101323  16054      1]\n",
+            "\n",
+            "Example 1:\n",
+            "src: [     2  49688    736   1280   6987 235292    108   2437  87150    477\n",
+            "    476  11709 230461   8045   3636  40268    576   4252   4897 235336\n",
+            "    108]\n",
+            "dst: [     2 213606    477   1455 235290   3510    748   8268 191017   2809\n",
+            "    581   2032  69972    581  11495   1305    533 235303  65978   1654\n",
+            "      1]\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "tokenizer = GemmaTokenizer(vocab)\n",
+        "\n",
+        "def tokenize_source(tokenizer, example: tf.Tensor):\n",
+        "  return tokenizer.tokenize_tf_op(example,\n",
+        "                                  prefix='Translate this into French:\\n',\n",
+        "                                  suffix='\\n',\n",
+        "                                  add_eos=False)\n",
+        "def tokenize_destination(tokenizer, example: tf.Tensor):\n",
+        "  return tokenizer.tokenize_tf_op(example,\n",
+        "                                  add_eos=True)\n",
+        "\n",
+        "ds = tfds.load(\"mtnt/en-fr\",split=\"train\")\n",
+        "ds = ds.take(2)\n",
+        "ds = ds.map(lambda x: {'src': tokenize_source(tokenizer, x['src']),\n",
+        "                       'dst': tokenize_destination(tokenizer, x['dst'])})\n",
+        "ds = ds.as_numpy_iterator()\n",
+        "\n",
+        "for idx, example in enumerate(ds):\n",
+        "  print(f'Example {idx}:')\n",
+        "  for key, val in example.items():\n",
+        "    print(f'{key}: {val}')\n",
+        "  print()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qkY_hThVkkqF"
+      },
+      "source": [
+        "Build a data loader for the entire MTNT dataset:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "id": "Zm30Q2lnknmG"
+      },
+      "outputs": [],
+      "source": [
+        "@chex.dataclass(frozen=True)\n",
+        "class TrainingInput:\n",
+        "  # Input tokens provided to the model.\n",
+        "  input_tokens: jax.Array\n",
+        "\n",
+        "  # A mask that determines which tokens contribute to the target loss\n",
+        "  # calculation.\n",
+        "  target_mask: jax.Array\n",
+        "\n",
+        "class DatasetSplit(enum.Enum):\n",
+        "  TRAIN = 'train'\n",
+        "  VALIDATION = 'valid'\n",
+        "\n",
+        "class MTNTDatasetBuilder:\n",
+        "  \"\"\"The dataset builder for the MTNT dataset.\"\"\"\n",
+        "\n",
+        "  N_ITEMS = {DatasetSplit.TRAIN: 35_692,\n",
+        "             DatasetSplit.VALIDATION: 811}\n",
+        "\n",
+        "  BUFFER_SIZE_SHUFFLE = 10_000\n",
+        "  TRANSLATION_PREFIX = 'Translate this into French:\\n'\n",
+        "  TRANSLATION_SUFFIX = '\\n'\n",
+        "\n",
+        "  def __init__(self,\n",
+        "               tokenizer : GemmaTokenizer,\n",
+        "               max_seq_len: int):\n",
+        "    \"\"\"Constructor.\n",
+        "\n",
+        "    Args:\n",
+        "      tokenizer: Gemma tokenizer to use.\n",
+        "      max_seq_len: size of each sequence in a given batch.\n",
+        "    \"\"\"\n",
+        "    self._tokenizer = tokenizer\n",
+        "    self._base_data = {\n",
+        "        DatasetSplit.TRAIN: tfds.load(\"mtnt/en-fr\",split=\"train\"),\n",
+        "        DatasetSplit.VALIDATION: tfds.load(\"mtnt/en-fr\",split=\"valid\"),\n",
+        "    }\n",
+        "    self._max_seq_len = max_seq_len\n",
+        "\n",
+        "  def _tokenize_source(self, example: tf.Tensor):\n",
+        "    \"\"\"Tokenization function for the source.\"\"\"\n",
+        "    return self._tokenizer.tokenize_tf_op(example,\n",
+        "                                          prefix=self.TRANSLATION_PREFIX,\n",
+        "                                          suffix=self.TRANSLATION_SUFFIX,\n",
+        "                                          add_eos=False)\n",
+        "\n",
+        "  def _tokenize_destination(self, example: tf.Tensor):\n",
+        "    \"\"\"Tokenization function for the French translation.\"\"\"\n",
+        "    return self._tokenizer.tokenize_tf_op(example,\n",
+        "                                          add_eos=True)\n",
+        "\n",
+        "  def _pad_up_to_max_len(self,\n",
+        "                         input_tensor: tf.Tensor,\n",
+        "                         pad_value: int | bool,\n",
+        "                         ) -> tf.Tensor:\n",
+        "    \"\"\"Pad the given tensor up to sequence length of a batch.\"\"\"\n",
+        "    seq_len = tf.shape(input_tensor)[0]\n",
+        "    to_pad = tf.maximum(self._max_seq_len - seq_len, 0)\n",
+        "    return tf.pad(input_tensor,\n",
+        "                  [[0, to_pad]],\n",
+        "                  mode='CONSTANT',\n",
+        "                  constant_values=pad_value,\n",
+        "                  )\n",
+        "\n",
+        "  def _to_training_input(self,\n",
+        "                         src_tokens: jax.Array,\n",
+        "                         dst_tokens: jax.Array,\n",
+        "                         ) -> TrainingInput:\n",
+        "    \"\"\"Build a training input from a tuple of source and destination tokens.\"\"\"\n",
+        "\n",
+        "    # The input sequence fed to the model is simply the concatenation of the\n",
+        "    # source and the destination.\n",
+        "    tokens = tf.concat([src_tokens, dst_tokens], axis=0)\n",
+        "\n",
+        "    # To prevent the model from updating based on the source (input)\n",
+        "    # tokens, add a target mask to each input.\n",
+        "    q_mask = tf.zeros_like(src_tokens, dtype=tf.bool)\n",
+        "    a_mask = tf.ones_like(dst_tokens, dtype=tf.bool)\n",
+        "    mask = tf.concat([q_mask, a_mask], axis=0)\n",
+        "\n",
+        "    # If the output tokens sequence is smaller than the target sequence size,\n",
+        "    # then pad it with pad tokens.\n",
+        "    tokens = self._pad_up_to_max_len(tokens, self._tokenizer.pad_id)\n",
+        "\n",
+        "    # Don't want to perform the backward pass on the pad tokens.\n",
+        "    mask = self._pad_up_to_max_len(mask, False)\n",
+        "\n",
+        "    return TrainingInput(input_tokens=tokens, target_mask=mask)\n",
+        "\n",
+        "\n",
+        "  def get_train_dataset(self, batch_size: int, num_epochs: int):\n",
+        "    \"\"\"Build the training dataset.\"\"\"\n",
+        "\n",
+        "    # Tokenize each sample.\n",
+        "    ds = self._base_data[DatasetSplit.TRAIN].map(lambda x : (self._tokenize_source(x['src']),\n",
+        "                                                             self._tokenize_destination(x['dst'])))\n",
+        "\n",
+        "    # Convert the samples to training inputs.\n",
+        "    ds = ds.map(lambda x, y: self._to_training_input(x, y))\n",
+        "\n",
+        "    # Remove the samples that are too long.\n",
+        "    ds = ds.filter(lambda x: tf.shape(x.input_tokens)[0] <= self._max_seq_len)\n",
+        "\n",
+        "    # Shuffle the dataset.\n",
+        "    ds = ds.shuffle(buffer_size=self.BUFFER_SIZE_SHUFFLE)\n",
+        "\n",
+        "    # Repeat if necessary.\n",
+        "    ds = ds.repeat(num_epochs)\n",
+        "\n",
+        "    # Build batches.\n",
+        "    ds = ds.batch(batch_size, drop_remainder=True)\n",
+        "    return ds\n",
+        "\n",
+        "  def get_validation_dataset(self, batch_size: int):\n",
+        "    \"\"\"Build the validation dataset.\"\"\"\n",
+        "\n",
+        "    # Same steps as in `get_train_dataset`, but without shuffling and no repetition.\n",
+        "    ds = self._base_data[DatasetSplit.VALIDATION].map(lambda x : (self._tokenize_source(x['src']),\n",
+        "                                                                  self._tokenize_destination(x['dst'])))\n",
+        "    ds = ds.map(lambda x, y: self._to_training_input(x, y))\n",
+        "    ds = ds.filter(lambda x: tf.shape(x.input_tokens)[0] <= self._max_seq_len)\n",
+        "    ds = ds.batch(batch_size, drop_remainder=True)\n",
+        "    return ds"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "A3jRNKosyLUK"
+      },
+      "source": [
+        "Try the `MTNTDatasetBuilder` out by instantiating the custom `GemmaTokenizer` again, then applying it on the MTNT dataset, and sampling two examples:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "id": "bYeduOaNEcoZ"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n",
+            "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n",
+            "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Example 0:\n",
+            "input_tokens: [[     2  49688    736   1280   6987 235292    108  10924    665  12302\n",
+            "  235341    108      2   4397  63011   1437  38696   1241      1      0]\n",
+            " [     2  49688    736   1280   6987 235292    108  13835   1517 235265\n",
+            "     108      2  69875    540  19713 235265      1      0      0      0]\n",
+            " [     2  49688    736   1280   6987 235292    108   6956   1586 235297\n",
+            "  235265    108      2  78368   1586 235297 235265      1      0      0]]\n",
+            "target_mask: [[False False False False False False False False False False False False\n",
+            "   True  True  True  True  True  True  True False]\n",
+            " [False False False False False False False False False False False  True\n",
+            "   True  True  True  True  True False False False]\n",
+            " [False False False False False False False False False False False False\n",
+            "   True  True  True  True  True  True False False]]\n",
+            "\n",
+            "Example 1:\n",
+            "input_tokens: [[     2  49688    736   1280   6987 235292    108  18874 235341    108\n",
+            "       2 115905   6425   1241      1      0      0      0      0      0]\n",
+            " [     2  49688    736   1280   6987 235292    108   7574   3356 235341\n",
+            "     108      2   7997  20707   1241      1      0      0      0      0]\n",
+            " [     2  49688    736   1280   6987 235292    108   8703    665 235265\n",
+            "     108      2 235338 235303  90006  20133 235265      1      0      0]]\n",
+            "target_mask: [[False False False False False False False False False False  True  True\n",
+            "   True  True  True False False False False False]\n",
+            " [False False False False False False False False False False False  True\n",
+            "   True  True  True  True False False False False]\n",
+            " [False False False False False False False False False False False  True\n",
+            "   True  True  True  True  True  True False False]]\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "tokenizer = GemmaTokenizer(vocab)\n",
+        "\n",
+        "dataset_builder = MTNTDatasetBuilder(tokenizer, max_seq_len=20)\n",
+        "ds = dataset_builder.get_train_dataset(3, 1)\n",
+        "ds = ds.take(2)\n",
+        "ds = ds.as_numpy_iterator()\n",
+        "\n",
+        "for idx, example in enumerate(ds):\n",
+        "  print(f'Example {idx}:')\n",
+        "  for key, val in example.items():\n",
+        "    print(f'{key}: {val}')\n",
+        "  print()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7IY8Muu1zRF4"
+      },
+      "source": [
+        "## Configure the model\n",
+        "\n",
+        "Before you begin fine-tuning the Gemma model, you need to configure it.\n",
+        "\n",
+        "First, load and format the Gemma model checkpoint with the [`gemma.params.load_and_format_params`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/params.py#L27) method:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "id": "by6eWKtqzxRf"
+      },
+      "outputs": [],
+      "source": [
+        "params = params_lib.load_and_format_params(CKPT_PATH)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BtJhJkkZzsy1"
+      },
+      "source": [
+        "To automatically load the correct configuration from the Gemma model checkpoint, use [`gemma.transformer.TransformerConfig`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L65). The `cache_size` argument is the number of time steps in the Gemma `Transformer` cache. Afterwards, instantiate the Gemma model as `model_2b` with [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) (which inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html)).\n",
+        "\n",
+        "**Note:** The vocabulary size is smaller than the number of input embeddings because of unused tokens in the current Gemma release."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "id": "_jjlFAkazzit"
+      },
+      "outputs": [],
+      "source": [
+        "config_2b = transformer_lib.TransformerConfig.from_params(\n",
+        "    params,\n",
+        "    cache_size=30\n",
+        ")\n",
+        "\n",
+        "model_2b = transformer_lib.Transformer(config=config_2b)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "t7UL2Af536x_"
+      },
+      "source": [
+        "## Fine-tune the model\n",
+        "\n",
+        "In this section, you will:\n",
+        "\n",
+        "- Use the `gemma.transformer.Transformer` class to create the forward pass and loss function.\n",
+        "- Build the position and attention mask vectors for tokens\n",
+        "- Build a training step function with Flax.\n",
+        "- Build the validation step without the backwards pass.\n",
+        "- Create the training loop.\n",
+        "- Fine-tune the Gemma model."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aJhtJumH7H8_"
+      },
+      "source": [
+        "Define the forward pass and the loss function using the [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) class. The Gemma `Transformer` inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html), and offers two essential methods:\n",
+        "\n",
+        "- `init`: Initializes the model's parameters.\n",
+        "- `apply`: Executes the model's `__call__` function using a given set of parameters.\n",
+        "\n",
+        "  Since you are working with pre-trained Gemma weights, you don't need to use the `init` function."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "id": "iEcV0XEEEcoZ"
+      },
+      "outputs": [],
+      "source": [
+        "def forward_and_loss_fn(params,\n",
+        "                        *,\n",
+        "                        model: transformer_lib.Transformer,\n",
+        "                        input_tokens: jax.Array,            # Shape [B, L]\n",
+        "                        input_mask: jax.Array,              # Shape [B, L]\n",
+        "                        positions: jax.Array,               # Shape [B, L]\n",
+        "                        attention_mask: jax.Array,          # [B, L, L]\n",
+        "                        ) -> jax.Array:\n",
+        "  \"\"\"The forward pass and the loss function.\n",
+        "\n",
+        "  Args:\n",
+        "    params: Model's input parameters.\n",
+        "    model: The Gemma transformer model to call.\n",
+        "    input_tokens: Input tokens sequence, shape [B, L].\n",
+        "    input_mask: Tokens to ignore when computing the loss, shape [B, L].\n",
+        "    positions: Relative position of each token, shape [B, L].\n",
+        "    attention_mask: Input attention mask, shape [B, L].\n",
+        "\n",
+        "  Returns:\n",
+        "    The softmax cross-entropy loss for the next-token prediction task.\n",
+        "  \"\"\"\n",
+        "\n",
+        "  # The forward pass on the input data.\n",
+        "  # No attention cache is needed here.\n",
+        "  logits, _ = model.apply(\n",
+        "        params,\n",
+        "        input_tokens,\n",
+        "        positions,\n",
+        "        None,              # Attention cache is None.\n",
+        "        attention_mask,\n",
+        "    )\n",
+        "\n",
+        "  # Exclude the last step as it does not appear in the targets.\n",
+        "  logits = logits[0, :-1]\n",
+        "\n",
+        "  # Similarly, the first token cannot be predicted.\n",
+        "  target_tokens = input_tokens[0, 1:]\n",
+        "  target_mask = input_mask[0, 1:]\n",
+        "\n",
+        "  # Convert the target labels to one-hot encoded vectors.\n",
+        "  one_hot = jax.nn.one_hot(target_tokens, logits.shape[-1])\n",
+        "\n",
+        "  # Don't update on unwanted tokens.\n",
+        "  one_hot = one_hot * target_mask.astype(one_hot.dtype)[...,None]\n",
+        "\n",
+        "  # Define the normalization factor.\n",
+        "  norm_factor = 1 / (jnp.sum(target_mask) + 1e-8)\n",
+        "\n",
+        "  # Return the negative log likelihood (NLL) loss.\n",
+        "  return -jnp.sum(jax.nn.log_softmax(logits) * one_hot) * norm_factor"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WxbxsKcd7Ot7"
+      },
+      "source": [
+        "The [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) class requires an `attention_mask` and a `positions` vector alongside each input. You can generate these by creating a custom function that uses [`Transformer.build_positions_from_mask`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L48) and [`Transformer.make_causal_attn_mask`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L29):\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "metadata": {
+        "id": "cbWfdHf0EcoZ"
+      },
+      "outputs": [],
+      "source": [
+        "def get_attention_mask_and_positions(example: jax.Array,\n",
+        "                                     pad_id : int,\n",
+        "                                     )-> tuple[jax.Array, jax.Array]:\n",
+        "  \"\"\"Builds the position and attention mask vectors from the given tokens.\"\"\"\n",
+        "  pad_mask = example != pad_id\n",
+        "  current_token_position = transformer_lib.build_positions_from_mask(pad_mask)\n",
+        "  attention_mask = transformer_lib.make_causal_attn_mask(pad_mask)\n",
+        "  return current_token_position, attention_mask"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "uRkeF6ed8tOI"
+      },
+      "source": [
+        "Build the `train_step` function that performs the backward pass and updates the model's parameters accordingly, where:\n",
+        "\n",
+        "- [`jax.value_and_grad`](https://jax.readthedocs.io/en/latest/_autosummary/jax.value_and_grad.html) is for evaluating the loss function and gradients during the forward and backward passes.\n",
+        "- [`optax.apply_updates`](https://optax.readthedocs.io/en/latest/api/apply_updates.html#optax.apply_updates) is for updating the parameters."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "id": "cPSfp7ZUEcoZ"
+      },
+      "outputs": [],
+      "source": [
+        "def train_step(model: transformer_lib.Transformer,\n",
+        "               params,\n",
+        "               optimizer: optax.GradientTransformation,\n",
+        "               opt_state: optax.OptState,\n",
+        "               pad_id: int,\n",
+        "               example: TrainingInput):\n",
+        "  \"\"\"Train step.\n",
+        "\n",
+        "  Args:\n",
+        "    model: The Gemma transformer model.\n",
+        "    params: The model's input parameters.\n",
+        "    optimizer: The Optax optimizer to use.\n",
+        "    opt_state: The input optimizer's state.\n",
+        "    pad_id: ID of the pad token.\n",
+        "    example: Input batch.\n",
+        "\n",
+        "  Returns:\n",
+        "    The training loss, the updated parameters, and the updated optimizer state.\n",
+        "  \"\"\"\n",
+        "\n",
+        "  # Build the position and attention mask vectors.\n",
+        "  positions, attention_mask = get_attention_mask_and_positions(example.input_tokens, pad_id)\n",
+        "\n",
+        "  # The forward and backward passes.\n",
+        "  train_loss, grads = jax.value_and_grad(forward_and_loss_fn)(params,\n",
+        "                                                             model=model,\n",
+        "                                                             input_tokens=example.input_tokens,\n",
+        "                                                             input_mask=example.target_mask,\n",
+        "                                                             positions=positions,\n",
+        "                                                             attention_mask=attention_mask)\n",
+        "  # Update the parameters.\n",
+        "  updates, opt_state = optimizer.update(grads, opt_state)\n",
+        "  params = optax.apply_updates(params, updates)\n",
+        "\n",
+        "  return train_loss, params, opt_state"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8ZKSa-jJ809n"
+      },
+      "source": [
+        "Build the `validation_step` function without the backward pass:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "id": "yU4oR92YEcoa"
+      },
+      "outputs": [],
+      "source": [
+        "def validation_step(model: transformer_lib.Transformer,\n",
+        "                    params,\n",
+        "                    pad_id: int,\n",
+        "                    example: TrainingInput,\n",
+        "                    ):\n",
+        "  positions, attention_mask = get_attention_mask_and_positions(example.input_tokens, pad_id)\n",
+        "  val_loss = forward_and_loss_fn(params,\n",
+        "                                 model=model,\n",
+        "                                 input_tokens=example.input_tokens,\n",
+        "                                 input_mask=example.target_mask,\n",
+        "                                 positions=positions,\n",
+        "                                 attention_mask=attention_mask)\n",
+        "  return val_loss"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bNqVhj7v87f4"
+      },
+      "source": [
+        "Define the training loop using [`optax.sgd`](https://optax.readthedocs.io/en/latest/api/optimizers.html#optax.sgd) for the SGD optimizer:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "id": "xT4bAqNLEcoa"
+      },
+      "outputs": [],
+      "source": [
+        "@chex.dataclass(frozen=True)\n",
+        "class TrainingConfig:\n",
+        "  learning_rate: float\n",
+        "  num_epochs: int\n",
+        "  eval_every_n: int\n",
+        "  batch_size: int\n",
+        "  max_steps: int | None = None\n",
+        "\n",
+        "def train_loop(\n",
+        "    model: transformer_lib.Transformer,\n",
+        "    params,\n",
+        "    dataset_builder: MTNTDatasetBuilder,\n",
+        "    training_cfg: TrainingConfig):\n",
+        "\n",
+        "  # Apply `jax.jit` on the training step, making the whole loop much more efficient.\n",
+        "  compiled_train_step = jax.jit(train_step, static_argnames=['model', 'optimizer'])\n",
+        "\n",
+        "  # Apply `jax.jit` on the validation step.\n",
+        "  compiled_validation_step = jax.jit(validation_step, static_argnames=['model'])\n",
+        "\n",
+        "  # To save memory, use the SGD optimizer instead of the usual Adam optimizer.\n",
+        "  # Note that for this specific example, SGD is more than enough.\n",
+        "  optimizer = optax.sgd(training_cfg.learning_rate)\n",
+        "  opt_state = optimizer.init(params)\n",
+        "\n",
+        "  # Build the training dataset.\n",
+        "  train_ds = dataset_builder.get_train_dataset(batch_size=training_cfg.batch_size,\n",
+        "                                               num_epochs=training_cfg.num_epochs)\n",
+        "  train_ds = train_ds.as_numpy_iterator()\n",
+        "\n",
+        "  # Build the validation dataset, with a limited number of samples for this demo.\n",
+        "  validation_ds = dataset_builder.get_validation_dataset(batch_size=training_cfg.batch_size)\n",
+        "  validation_ds = validation_ds.take(50)\n",
+        "\n",
+        "  n_steps = 0\n",
+        "  avg_loss=0\n",
+        "\n",
+        "  # A first round of the validation loss.\n",
+        "  n_steps_eval = 0\n",
+        "  eval_loss = 0\n",
+        "  val_iterator = validation_ds.as_numpy_iterator()\n",
+        "  for val_example in val_iterator:\n",
+        "    eval_loss += compiled_validation_step(model,\n",
+        "                                          params,\n",
+        "                                          dataset_builder._tokenizer.pad_id,\n",
+        "                                          val_example)\n",
+        "    n_steps_eval += 1\n",
+        "  print(f\"Start, validation loss: {eval_loss/n_steps_eval}\")\n",
+        "\n",
+        "  for train_example in train_ds:\n",
+        "    train_loss, params, opt_state = compiled_train_step(model=model,\n",
+        "                                                        params=params,\n",
+        "                                                        optimizer=optimizer,\n",
+        "                                                        opt_state=opt_state,\n",
+        "                                                        pad_id=dataset_builder._tokenizer.pad_id,\n",
+        "                                                        example=train_example)\n",
+        "    n_steps += 1\n",
+        "    avg_loss += train_loss\n",
+        "    if n_steps % training_cfg.eval_every_n == 0:\n",
+        "      eval_loss = 0\n",
+        "\n",
+        "      n_steps_eval = 0\n",
+        "      val_iterator = validation_ds.as_numpy_iterator()\n",
+        "      for val_example in val_iterator:\n",
+        "        eval_loss += compiled_validation_step(model,\n",
+        "                                              params,\n",
+        "                                              dataset_builder._tokenizer.pad_id,\n",
+        "                                              val_example)\n",
+        "        n_steps_eval +=1\n",
+        "      avg_loss /= training_cfg.eval_every_n\n",
+        "      eval_loss /= n_steps_eval\n",
+        "      print(f\"STEP {n_steps} training loss: {avg_loss} - eval loss: {eval_loss}\")\n",
+        "      avg_loss=0\n",
+        "    if training_cfg.max_steps is not None and n_steps > training_cfg.max_steps:\n",
+        "      break\n",
+        "  return params"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ecv6lp5MCzFc"
+      },
+      "source": [
+        "Begin fine-tuning the Gemma model on a limited number of steps (`SEQ_SIZE`) to make sure this fits in the memory:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "id": "7SL2VAmVEcoa"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Start, validation loss: 10.647212982177734\n",
+            "STEP 20 training loss: 3.3015992641448975 - eval loss: 2.686880111694336\n",
+            "STEP 40 training loss: 5.375057220458984 - eval loss: 2.6751961708068848\n",
+            "STEP 60 training loss: 2.6599338054656982 - eval loss: 2.663877010345459\n",
+            "STEP 80 training loss: 4.822389125823975 - eval loss: 2.3333375453948975\n",
+            "STEP 100 training loss: 2.0131142139434814 - eval loss: 2.360811948776245\n"
+          ]
+        }
+      ],
+      "source": [
+        "SEQ_SIZE = 25\n",
+        "tokenizer = GemmaTokenizer(vocab)\n",
+        "dataset_builder= MTNTDatasetBuilder(tokenizer, SEQ_SIZE)\n",
+        "training_cfg = TrainingConfig(learning_rate=1e-4,\n",
+        "                              num_epochs=1,\n",
+        "                              eval_every_n=20,\n",
+        "                              batch_size=1,\n",
+        "                              max_steps=100)\n",
+        "\n",
+        "params = train_loop(model=model_2b,\n",
+        "                    params={'params': params['transformer']},\n",
+        "                    dataset_builder=dataset_builder,\n",
+        "                    training_cfg=training_cfg)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EtfVo3pDDAZV"
+      },
+      "source": [
+        "Both the training loss and the validation loss should have gone down with each step count.\n",
+        "\n",
+        "Create a `sampler` with [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/sampler.py#L88). It uses the Gemma model checkpoint and the tokenizer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "id": "dQ1oCF10Ecod"
+      },
+      "outputs": [],
+      "source": [
+        "sampler = sampler_lib.Sampler(\n",
+        "    transformer=model_2b,\n",
+        "    vocab=vocab,\n",
+        "    params=params['params'],\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-61KZz7EHiIS"
+      },
+      "source": [
+        "Use the `sampler` to check if your model can perform translation. The `total_generation_steps` argument in [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/sampler.py#L88) is the number of steps performed when generating a response. To ensure the input matches the training format, use the prefix `Translate this into French:\\n` with a newline character at the end. This signals the model to begin translation.\n",
+        "\n",
+        "**Note:** Due to hardware restrictions, the number of training parameters used in the gemma Transformer may not be sufficient to produce \"stable\" results in this demo.\n",
+        "\n",
+        "**Note:** If you run out of memory, click on **Runtime** > **Disconnect and delete runtime**, and then **Runtime** > **Run all**.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "id": "S5F3fk22Ecod"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[\"C'est Bonjour, mon nom est Morgane.C'est Bonjour, mon nom est Morgane.\"]"
+            ]
+          },
+          "execution_count": 23,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "sampler(\n",
+        "    [\"Translate this into French:\\nHello, my name is Morgane.\\n\"],\n",
+        "    total_generation_steps=100,\n",
+        "    ).text"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Jao0Qk-ZIqyD"
+      },
+      "source": [
+        "## Learn more\n",
+        "\n",
+        "- You can learn more about the Google DeepMind [`gemma`  library on GitHub](https://github.com/google-deepmind/gemma), which contains docstrings of modules you used in this tutorial, such as [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py),\n",
+        "[`gemma.transformer`](https://github.com/google-deepmind/gemma/blob/main/gemma/transformer.py), and\n",
+        "[`gemma.sampler`](https://github.com/google-deepmind/gemma/blob/main/gemma/sampler.py).\n",
+        "- The following libraries have their own documentation sites: [core JAX](https://jax.readthedocs.io), [Flax](https://flax.readthedocs.io), [Chex](https://chex.readthedocs.io/en/latest/), [Optax](https://optax.readthedocs.io/en/latest/), and [Orbax](https://orbax.readthedocs.io/).\n",
+        "- For `sentencepiece` tokenizer/detokenizer documentation, check out [Google's `sentencepiece` GitHub repo](https://github.com/google/sentencepiece).\n",
+        "- For `kagglehub` documentation, check out `README.md` on [Kaggle's `kagglehub` GitHub repo](https://github.com/Kaggle/kagglehub).\n",
+        "- Learn how to [use Gemma models with Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/open-models/use-gemma).\n",
+        "- If you are using Google Cloud TPUs (v3-8 and newer), make sure to also update to the latest `jax[tpu]` package (`!pip install -U jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html`), restart the runtime, and check that `jax` and `jaxlib` versions match (`!pip list | grep jax`). This can prevent the `RuntimeError` that can arise because of the `jaxlib` and `jax` version mismatch. For more JAX installation instructions, refer to the [JAX docs](https://jax.readthedocs.io/en/latest/tutorials/installation.html#install-google-tpu)."
+      ]
     }
-   ],
-   "source": [
-    "ds = tfds.load(\"mtnt/en-fr\", split=\"train\")\n",
-    "\n",
-    "ds = ds.take(2)\n",
-    "ds = ds.as_numpy_iterator()\n",
-    "\n",
-    "for idx, example in enumerate(ds):\n",
-    "  print(f'Example {idx}:')\n",
-    "  for key, val in example.items():\n",
-    "    print(f'{key}: {val}')\n",
-    "  print()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "XlY3EYV6jXWR"
-   },
-   "source": [
-    "Load the Gemma tokenizer, constructed using [`sentencepiece.SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "id": "TpyG5YW1EcoY"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "vocab = spm.SentencePieceProcessor()\n",
-    "vocab.Load(TOKENIZER_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Mk_CV0A1kR4K"
-   },
-   "source": [
-    "Customize the[`SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423) for the English-to-French translation task. Since you will be fine-tuning the English portion of the Gemma model, you need to make a few adjustments, such as:\n",
-    "\n",
-    "- *The input prefix*: Adding a common prefix to each input signals the translation task. For example, you could use a prompt with a prefix like `Translate this into French: [INPUT_SENTENCE]`.\n",
-    "\n",
-    "- *The translation start suffix*: Adding a suffix at the end of each prompt instructs the Gemma model exactly when to begin the translation process. A new line should do the job.\n",
-    "\n",
-    "- *Language model tokens*: Gemma models expect a \"beginning of sequence\" token at the beginning of each sequence, so adding an \"end of sequence\" token at the end of each training example should be sufficient.\n",
-    "\n",
-    "  Build a custom wrapper around the `SentencePieceProcessor` as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "id": "L9cjK0uxEcoY"
-   },
-   "outputs": [],
-   "source": [
-    "class GemmaTokenizer:\n",
-    "\n",
-    "  def __init__(self,\n",
-    "               spm_processor: spm.SentencePieceProcessor):\n",
-    "    self._spm_processor = spm_processor\n",
-    "\n",
-    "  @property\n",
-    "  def pad_id(self) -> int:\n",
-    "    \"\"\"Fast access to the pad ID.\"\"\"\n",
-    "    return self._spm_processor.pad_id()\n",
-    "\n",
-    "  def tokenize(self,\n",
-    "               example: str | bytes,\n",
-    "               prefix: str = '',\n",
-    "               suffix: str = '',\n",
-    "               add_eos: bool = True) -> jax.Array:\n",
-    "    \"\"\"\n",
-    "    The tokenization function.\n",
-    "\n",
-    "    Args:\n",
-    "      example: Input string to tokenize.\n",
-    "      prefix:  Prefix to add to the input string.\n",
-    "      suffix:  Suffix to add to the input string.\n",
-    "      add_eos: If True, add an \"end of sentence\" token at the end of the output\n",
-    "               sequence.\n",
-    "    Returns:\n",
-    "      Tokens corresponding to the input string.\n",
-    "    \"\"\"\n",
-    "    int_list = [self._spm_processor.bos_id()]\n",
-    "    int_list.extend(self._spm_processor.EncodeAsIds(prefix + example + suffix))\n",
-    "    if add_eos:\n",
-    "      int_list.append(self._spm_processor.eos_id())\n",
-    "\n",
-    "    return jnp.array(int_list, dtype=jnp.int32)\n",
-    "\n",
-    "  def tokenize_tf_op(self,\n",
-    "                     str_tensor: tf.Tensor,\n",
-    "                     prefix: str = '',\n",
-    "                     suffix: str = '',\n",
-    "                     add_eos: bool = True) -> tf.Tensor:\n",
-    "    \"\"\"A TensorFlow operator for the tokenize function.\"\"\"\n",
-    "    encoded = tf.numpy_function(\n",
-    "        self.tokenize,\n",
-    "        [str_tensor, prefix, suffix, add_eos],\n",
-    "        tf.int32)\n",
-    "    encoded.set_shape([None])\n",
-    "    return encoded\n",
-    "\n",
-    "  def to_string(self, tokens: jax.Array) -> str:\n",
-    "    \"\"\"Convert an array of tokens to a string.\"\"\"\n",
-    "    return self._spm_processor.EncodeIds(tokens.tolist())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "h-oJ2ziwxG1L"
-   },
-   "source": [
-    "Try it out by instantiating your new custom `GemmaTokenizer`, and then applying it on a small sample of the MTNT dataset:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "id": "xEA-97ioEcoY"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Example 0:\n",
-      "src: [     2  49688    736   1280   6987 235292    108    651   2778    576\n",
-      "   1080 104745  11982   5736    832   8995    901    780   3547    665\n",
-      "    575    573   4589 235369   2778 235265    108]\n",
-      "dst: [     2   2025  29653    581    664  16298   1437  55563  41435   7840\n",
-      "    581    683 111452    581    533 235303   9776   4108   2459    679\n",
-      "    485 235303    479   6728    579   1806   2499    709  29653    581\n",
-      "    533 235303 101323  16054      1]\n",
-      "\n",
-      "Example 1:\n",
-      "src: [     2  49688    736   1280   6987 235292    108   2437  87150    477\n",
-      "    476  11709 230461   8045   3636  40268    576   4252   4897 235336\n",
-      "    108]\n",
-      "dst: [     2 213606    477   1455 235290   3510    748   8268 191017   2809\n",
-      "    581   2032  69972    581  11495   1305    533 235303  65978   1654\n",
-      "      1]\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "tokenizer = GemmaTokenizer(vocab)\n",
-    "\n",
-    "def tokenize_source(tokenizer, example: tf.Tensor):\n",
-    "  return tokenizer.tokenize_tf_op(example,\n",
-    "                                  prefix='Translate this into French:\\n',\n",
-    "                                  suffix='\\n',\n",
-    "                                  add_eos=False)\n",
-    "def tokenize_destination(tokenizer, example: tf.Tensor):\n",
-    "  return tokenizer.tokenize_tf_op(example,\n",
-    "                                  add_eos=True)\n",
-    "\n",
-    "ds = tfds.load(\"mtnt/en-fr\",split=\"train\")\n",
-    "ds = ds.take(2)\n",
-    "ds = ds.map(lambda x: {'src': tokenize_source(tokenizer, x['src']),\n",
-    "                       'dst': tokenize_destination(tokenizer, x['dst'])})\n",
-    "ds = ds.as_numpy_iterator()\n",
-    "\n",
-    "for idx, example in enumerate(ds):\n",
-    "  print(f'Example {idx}:')\n",
-    "  for key, val in example.items():\n",
-    "    print(f'{key}: {val}')\n",
-    "  print()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "qkY_hThVkkqF"
-   },
-   "source": [
-    "Build a data loader for the entire MTNT dataset:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "id": "Zm30Q2lnknmG"
-   },
-   "outputs": [],
-   "source": [
-    "@chex.dataclass(frozen=True)\n",
-    "class TrainingInput:\n",
-    "  # Input tokens provided to the model.\n",
-    "  input_tokens: jax.Array\n",
-    "\n",
-    "  # A mask that determines which tokens contribute to the target loss\n",
-    "  # calculation.\n",
-    "  target_mask: jax.Array\n",
-    "\n",
-    "class DatasetSplit(enum.Enum):\n",
-    "  TRAIN = 'train'\n",
-    "  VALIDATION = 'valid'\n",
-    "\n",
-    "class MTNTDatasetBuilder:\n",
-    "  \"\"\"The dataset builder for the MTNT dataset.\"\"\"\n",
-    "\n",
-    "  N_ITEMS = {DatasetSplit.TRAIN: 35_692,\n",
-    "             DatasetSplit.VALIDATION: 811}\n",
-    "\n",
-    "  BUFFER_SIZE_SHUFFLE = 10_000\n",
-    "  TRANSLATION_PREFIX = 'Translate this into French:\\n'\n",
-    "  TRANSLATION_SUFFIX = '\\n'\n",
-    "\n",
-    "  def __init__(self,\n",
-    "               tokenizer : GemmaTokenizer,\n",
-    "               max_seq_len: int):\n",
-    "    \"\"\"Constructor.\n",
-    "\n",
-    "    Args:\n",
-    "      tokenizer: Gemma tokenizer to use.\n",
-    "      max_seq_len: size of each sequence in a given batch.\n",
-    "    \"\"\"\n",
-    "    self._tokenizer = tokenizer\n",
-    "    self._base_data = {\n",
-    "        DatasetSplit.TRAIN: tfds.load(\"mtnt/en-fr\",split=\"train\"),\n",
-    "        DatasetSplit.VALIDATION: tfds.load(\"mtnt/en-fr\",split=\"valid\"),\n",
-    "    }\n",
-    "    self._max_seq_len = max_seq_len\n",
-    "\n",
-    "  def _tokenize_source(self, example: tf.Tensor):\n",
-    "    \"\"\"Tokenization function for the source.\"\"\"\n",
-    "    return self._tokenizer.tokenize_tf_op(example,\n",
-    "                                          prefix=self.TRANSLATION_PREFIX,\n",
-    "                                          suffix=self.TRANSLATION_SUFFIX,\n",
-    "                                          add_eos=False)\n",
-    "\n",
-    "  def _tokenize_destination(self, example: tf.Tensor):\n",
-    "    \"\"\"Tokenization function for the French translation.\"\"\"\n",
-    "    return self._tokenizer.tokenize_tf_op(example,\n",
-    "                                          add_eos=True)\n",
-    "\n",
-    "  def _pad_up_to_max_len(self,\n",
-    "                         input_tensor: tf.Tensor,\n",
-    "                         pad_value: int | bool,\n",
-    "                         ) -> tf.Tensor:\n",
-    "    \"\"\"Pad the given tensor up to sequence length of a batch.\"\"\"\n",
-    "    seq_len = tf.shape(input_tensor)[0]\n",
-    "    to_pad = tf.maximum(self._max_seq_len - seq_len, 0)\n",
-    "    return tf.pad(input_tensor,\n",
-    "                  [[0, to_pad]],\n",
-    "                  mode='CONSTANT',\n",
-    "                  constant_values=pad_value,\n",
-    "                  )\n",
-    "\n",
-    "  def _to_training_input(self,\n",
-    "                         src_tokens: jax.Array,\n",
-    "                         dst_tokens: jax.Array,\n",
-    "                         ) -> TrainingInput:\n",
-    "    \"\"\"Build a training input from a tuple of source and destination tokens.\"\"\"\n",
-    "\n",
-    "    # The input sequence fed to the model is simply the concatenation of the\n",
-    "    # source and the destination.\n",
-    "    tokens = tf.concat([src_tokens, dst_tokens], axis=0)\n",
-    "\n",
-    "    # To prevent the model from updating based on the source (input)\n",
-    "    # tokens, add a target mask to each input.\n",
-    "    q_mask = tf.zeros_like(src_tokens, dtype=tf.bool)\n",
-    "    a_mask = tf.ones_like(dst_tokens, dtype=tf.bool)\n",
-    "    mask = tf.concat([q_mask, a_mask], axis=0)\n",
-    "\n",
-    "    # If the output tokens sequence is smaller than the target sequence size,\n",
-    "    # then pad it with pad tokens.\n",
-    "    tokens = self._pad_up_to_max_len(tokens, self._tokenizer.pad_id)\n",
-    "\n",
-    "    # Don't want to perform the backward pass on the pad tokens.\n",
-    "    mask = self._pad_up_to_max_len(mask, False)\n",
-    "\n",
-    "    return TrainingInput(input_tokens=tokens, target_mask=mask)\n",
-    "\n",
-    "\n",
-    "  def get_train_dataset(self, batch_size: int, num_epochs: int):\n",
-    "    \"\"\"Build the training dataset.\"\"\"\n",
-    "\n",
-    "    # Tokenize each sample.\n",
-    "    ds = self._base_data[DatasetSplit.TRAIN].map(lambda x : (self._tokenize_source(x['src']),\n",
-    "                                                             self._tokenize_destination(x['dst'])))\n",
-    "\n",
-    "    # Convert the samples to training inputs.\n",
-    "    ds = ds.map(lambda x, y: self._to_training_input(x, y))\n",
-    "\n",
-    "    # Remove the samples that are too long.\n",
-    "    ds = ds.filter(lambda x: tf.shape(x.input_tokens)[0] <= self._max_seq_len)\n",
-    "\n",
-    "    # Shuffle the dataset.\n",
-    "    ds = ds.shuffle(buffer_size=self.BUFFER_SIZE_SHUFFLE)\n",
-    "\n",
-    "    # Repeat if necessary.\n",
-    "    ds = ds.repeat(num_epochs)\n",
-    "\n",
-    "    # Build batches.\n",
-    "    ds = ds.batch(batch_size, drop_remainder=True)\n",
-    "    return ds\n",
-    "\n",
-    "  def get_validation_dataset(self, batch_size: int):\n",
-    "    \"\"\"Build the validation dataset.\"\"\"\n",
-    "\n",
-    "    # Same steps as in `get_train_dataset`, but without shuffling and no repetition.\n",
-    "    ds = self._base_data[DatasetSplit.VALIDATION].map(lambda x : (self._tokenize_source(x['src']),\n",
-    "                                                                  self._tokenize_destination(x['dst'])))\n",
-    "    ds = ds.map(lambda x, y: self._to_training_input(x, y))\n",
-    "    ds = ds.filter(lambda x: tf.shape(x.input_tokens)[0] <= self._max_seq_len)\n",
-    "    ds = ds.batch(batch_size, drop_remainder=True)\n",
-    "    return ds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "A3jRNKosyLUK"
-   },
-   "source": [
-    "Try the `MTNTDatasetBuilder` out by instantiating the custom `GemmaTokenizer` again, then applying it on the MTNT dataset, and sampling two examples:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "id": "bYeduOaNEcoZ"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n",
-      "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n",
-      "WARNING:tensorflow:Mapping types may not work well with tf.nest. Prefer using MutableMapping for <class '__main__.TrainingInput'>\n"
-     ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "jax_finetune.ipynb",
+      "toc_visible": true
     },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Example 0:\n",
-      "input_tokens: [[     2  49688    736   1280   6987 235292    108  10924    665  12302\n",
-      "  235341    108      2   4397  63011   1437  38696   1241      1      0]\n",
-      " [     2  49688    736   1280   6987 235292    108  13835   1517 235265\n",
-      "     108      2  69875    540  19713 235265      1      0      0      0]\n",
-      " [     2  49688    736   1280   6987 235292    108   6956   1586 235297\n",
-      "  235265    108      2  78368   1586 235297 235265      1      0      0]]\n",
-      "target_mask: [[False False False False False False False False False False False False\n",
-      "   True  True  True  True  True  True  True False]\n",
-      " [False False False False False False False False False False False  True\n",
-      "   True  True  True  True  True False False False]\n",
-      " [False False False False False False False False False False False False\n",
-      "   True  True  True  True  True  True False False]]\n",
-      "\n",
-      "Example 1:\n",
-      "input_tokens: [[     2  49688    736   1280   6987 235292    108  18874 235341    108\n",
-      "       2 115905   6425   1241      1      0      0      0      0      0]\n",
-      " [     2  49688    736   1280   6987 235292    108   7574   3356 235341\n",
-      "     108      2   7997  20707   1241      1      0      0      0      0]\n",
-      " [     2  49688    736   1280   6987 235292    108   8703    665 235265\n",
-      "     108      2 235338 235303  90006  20133 235265      1      0      0]]\n",
-      "target_mask: [[False False False False False False False False False False  True  True\n",
-      "   True  True  True False False False False False]\n",
-      " [False False False False False False False False False False False  True\n",
-      "   True  True  True  True False False False False]\n",
-      " [False False False False False False False False False False False  True\n",
-      "   True  True  True  True  True  True False False]]\n",
-      "\n"
-     ]
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
     }
-   ],
-   "source": [
-    "tokenizer = GemmaTokenizer(vocab)\n",
-    "\n",
-    "dataset_builder = MTNTDatasetBuilder(tokenizer, max_seq_len=20)\n",
-    "ds = dataset_builder.get_train_dataset(3, 1)\n",
-    "ds = ds.take(2)\n",
-    "ds = ds.as_numpy_iterator()\n",
-    "\n",
-    "for idx, example in enumerate(ds):\n",
-    "  print(f'Example {idx}:')\n",
-    "  for key, val in example.items():\n",
-    "    print(f'{key}: {val}')\n",
-    "  print()"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "7IY8Muu1zRF4"
-   },
-   "source": [
-    "## Configure the model\n",
-    "\n",
-    "Before you begin fine-tuning the Gemma model, you need to configure it.\n",
-    "\n",
-    "First, load and format the Gemma model checkpoint with the [`gemma.params.load_and_format_params`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/params.py#L27) method:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "id": "by6eWKtqzxRf"
-   },
-   "outputs": [],
-   "source": [
-    "params = params_lib.load_and_format_params(CKPT_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "BtJhJkkZzsy1"
-   },
-   "source": [
-    "To automatically load the correct configuration from the Gemma model checkpoint, use [`gemma.transformer.TransformerConfig`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L65). The `cache_size` argument is the number of time steps in the Gemma `Transformer` cache. Afterwards, instantiate the Gemma model as `model_2b` with [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) (which inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html)).\n",
-    "\n",
-    "**Note:** The vocabulary size is smaller than the number of input embeddings because of unused tokens in the current Gemma release."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "id": "_jjlFAkazzit"
-   },
-   "outputs": [],
-   "source": [
-    "config_2b = transformer_lib.TransformerConfig.from_params(\n",
-    "    params,\n",
-    "    cache_size=30\n",
-    ")\n",
-    "\n",
-    "model_2b = transformer_lib.Transformer(config=config_2b)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "t7UL2Af536x_"
-   },
-   "source": [
-    "## Fine-tune the model\n",
-    "\n",
-    "In this section, you will:\n",
-    "\n",
-    "- Use the `gemma.transformer.Transformer` class to create the forward pass and loss function.\n",
-    "- Build the position and attention mask vectors for tokens\n",
-    "- Build a training step function with Flax.\n",
-    "- Build the validation step without the backwards pass.\n",
-    "- Create the training loop.\n",
-    "- Fine-tune the Gemma model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "aJhtJumH7H8_"
-   },
-   "source": [
-    "Define the forward pass and the loss function using the [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) class. The Gemma `Transformer` inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html), and offers two essential methods:\n",
-    "\n",
-    "- `init`: Initializes the model's parameters.\n",
-    "- `apply`: Executes the model's `__call__` function using a given set of parameters.\n",
-    "\n",
-    "  Since you are working with pre-trained Gemma weights, you don't need to use the `init` function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "id": "iEcV0XEEEcoZ"
-   },
-   "outputs": [],
-   "source": [
-    "def forward_and_loss_fn(params,\n",
-    "                        *,\n",
-    "                        model: transformer_lib.Transformer,\n",
-    "                        input_tokens: jax.Array,            # Shape [B, L]\n",
-    "                        input_mask: jax.Array,              # Shape [B, L]\n",
-    "                        positions: jax.Array,               # Shape [B, L]\n",
-    "                        attention_mask: jax.Array,          # [B, L, L]\n",
-    "                        ) -> jax.Array:\n",
-    "  \"\"\"The forward pass and the loss function.\n",
-    "\n",
-    "  Args:\n",
-    "    params: Model's input parameters.\n",
-    "    model: The Gemma transformer model to call.\n",
-    "    input_tokens: Input tokens sequence, shape [B, L].\n",
-    "    input_mask: Tokens to ignore when computing the loss, shape [B, L].\n",
-    "    positions: Relative position of each token, shape [B, L].\n",
-    "    attention_mask: Input attention mask, shape [B, L].\n",
-    "\n",
-    "  Returns:\n",
-    "    The softmax cross-entropy loss for the next-token prediction task.\n",
-    "  \"\"\"\n",
-    "\n",
-    "  # The forward pass on the input data.\n",
-    "  # No attention cache is needed here.\n",
-    "  logits, _ = model.apply(\n",
-    "        params,\n",
-    "        input_tokens,\n",
-    "        positions,\n",
-    "        None,              # Attention cache is None.\n",
-    "        attention_mask,\n",
-    "    )\n",
-    "\n",
-    "  # Exclude the last step as it does not appear in the targets.\n",
-    "  logits = logits[0, :-1]\n",
-    "\n",
-    "  # Similarly, the first token cannot be predicted.\n",
-    "  target_tokens = input_tokens[0, 1:]\n",
-    "  target_mask = input_mask[0, 1:]\n",
-    "\n",
-    "  # Convert the target labels to one-hot encoded vectors.\n",
-    "  one_hot = jax.nn.one_hot(target_tokens, logits.shape[-1])\n",
-    "\n",
-    "  # Don't update on unwanted tokens.\n",
-    "  one_hot = one_hot * target_mask.astype(one_hot.dtype)[...,None]\n",
-    "\n",
-    "  # Define the normalization factor.\n",
-    "  norm_factor = 1 / (jnp.sum(target_mask) + 1e-8)\n",
-    "\n",
-    "  # Return the negative log likelihood (NLL) loss.\n",
-    "  return -jnp.sum(jax.nn.log_softmax(logits) * one_hot) * norm_factor"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "WxbxsKcd7Ot7"
-   },
-   "source": [
-    "The [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) class requires an `attention_mask` and a `positions` vector alongside each input. You can generate these by creating a custom function that uses [`Transformer.build_positions_from_mask`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L48) and [`Transformer.make_causal_attn_mask`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L29):\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "id": "cbWfdHf0EcoZ"
-   },
-   "outputs": [],
-   "source": [
-    "def get_attention_mask_and_positions(example: jax.Array,\n",
-    "                                     pad_id : int,\n",
-    "                                     )-> tuple[jax.Array, jax.Array]:\n",
-    "  \"\"\"Builds the position and attention mask vectors from the given tokens.\"\"\"\n",
-    "  pad_mask = example != pad_id\n",
-    "  current_token_position = transformer_lib.build_positions_from_mask(pad_mask)\n",
-    "  attention_mask = transformer_lib.make_causal_attn_mask(pad_mask)\n",
-    "  return current_token_position, attention_mask"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "uRkeF6ed8tOI"
-   },
-   "source": [
-    "Build the `train_step` function that performs the backward pass and updates the model's parameters accordingly, where:\n",
-    "\n",
-    "- [`jax.value_and_grad`](https://jax.readthedocs.io/en/latest/_autosummary/jax.value_and_grad.html) is for evaluating the loss function and gradients during the forward and backward passes.\n",
-    "- [`optax.apply_updates`](https://optax.readthedocs.io/en/latest/api/apply_updates.html#optax.apply_updates) is for updating the parameters."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "id": "cPSfp7ZUEcoZ"
-   },
-   "outputs": [],
-   "source": [
-    "def train_step(model: transformer_lib.Transformer,\n",
-    "               params,\n",
-    "               optimizer: optax.GradientTransformation,\n",
-    "               opt_state: optax.OptState,\n",
-    "               pad_id: int,\n",
-    "               example: TrainingInput):\n",
-    "  \"\"\"Train step.\n",
-    "\n",
-    "  Args:\n",
-    "    model: The Gemma transformer model.\n",
-    "    params: The model's input parameters.\n",
-    "    optimizer: The Optax optimizer to use.\n",
-    "    opt_state: The input optimizer's state.\n",
-    "    pad_id: ID of the pad token.\n",
-    "    example: Input batch.\n",
-    "\n",
-    "  Returns:\n",
-    "    The training loss, the updated parameters, and the updated optimizer state.\n",
-    "  \"\"\"\n",
-    "\n",
-    "  # Build the position and attention mask vectors.\n",
-    "  positions, attention_mask = get_attention_mask_and_positions(example.input_tokens, pad_id)\n",
-    "\n",
-    "  # The forward and backward passes.\n",
-    "  train_loss, grads = jax.value_and_grad(forward_and_loss_fn)(params,\n",
-    "                                                             model=model,\n",
-    "                                                             input_tokens=example.input_tokens,\n",
-    "                                                             input_mask=example.target_mask,\n",
-    "                                                             positions=positions,\n",
-    "                                                             attention_mask=attention_mask)\n",
-    "  # Update the parameters.\n",
-    "  updates, opt_state = optimizer.update(grads, opt_state)\n",
-    "  params = optax.apply_updates(params, updates)\n",
-    "\n",
-    "  return train_loss, params, opt_state"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "8ZKSa-jJ809n"
-   },
-   "source": [
-    "Build the `validation_step` function without the backward pass:\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "id": "yU4oR92YEcoa"
-   },
-   "outputs": [],
-   "source": [
-    "def validation_step(model: transformer_lib.Transformer,\n",
-    "                    params,\n",
-    "                    pad_id: int,\n",
-    "                    example: TrainingInput,\n",
-    "                    ):\n",
-    "  positions, attention_mask = get_attention_mask_and_positions(example.input_tokens, pad_id)\n",
-    "  val_loss = forward_and_loss_fn(params,\n",
-    "                                 model=model,\n",
-    "                                 input_tokens=example.input_tokens,\n",
-    "                                 input_mask=example.target_mask,\n",
-    "                                 positions=positions,\n",
-    "                                 attention_mask=attention_mask)\n",
-    "  return val_loss"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bNqVhj7v87f4"
-   },
-   "source": [
-    "Define the training loop using [`optax.sgd`](https://optax.readthedocs.io/en/latest/api/optimizers.html#optax.sgd) for the SGD optimizer:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "id": "xT4bAqNLEcoa"
-   },
-   "outputs": [],
-   "source": [
-    "@chex.dataclass(frozen=True)\n",
-    "class TrainingConfig:\n",
-    "  learning_rate: float\n",
-    "  num_epochs: int\n",
-    "  eval_every_n: int\n",
-    "  batch_size: int\n",
-    "  max_steps: int | None = None\n",
-    "\n",
-    "def train_loop(\n",
-    "    model: transformer_lib.Transformer,\n",
-    "    params,\n",
-    "    dataset_builder: MTNTDatasetBuilder,\n",
-    "    training_cfg: TrainingConfig):\n",
-    "\n",
-    "  # Apply `jax.jit` on the training step, making the whole loop much more efficient.\n",
-    "  compiled_train_step = jax.jit(train_step, static_argnames=['model', 'optimizer'])\n",
-    "\n",
-    "  # Apply `jax.jit` on the validation step.\n",
-    "  compiled_validation_step = jax.jit(validation_step, static_argnames=['model'])\n",
-    "\n",
-    "  # To save memory, use the SGD optimizer instead of the usual Adam optimizer.\n",
-    "  # Note that for this specific example, SGD is more than enough.\n",
-    "  optimizer = optax.sgd(training_cfg.learning_rate)\n",
-    "  opt_state = optimizer.init(params)\n",
-    "\n",
-    "  # Build the training dataset.\n",
-    "  train_ds = dataset_builder.get_train_dataset(batch_size=training_cfg.batch_size,\n",
-    "                                               num_epochs=training_cfg.num_epochs)\n",
-    "  train_ds = train_ds.as_numpy_iterator()\n",
-    "\n",
-    "  # Build the validation dataset, with a limited number of samples for this demo.\n",
-    "  validation_ds = dataset_builder.get_validation_dataset(batch_size=training_cfg.batch_size)\n",
-    "  validation_ds = validation_ds.take(50)\n",
-    "\n",
-    "  n_steps = 0\n",
-    "  avg_loss=0\n",
-    "\n",
-    "  # A first round of the validation loss.\n",
-    "  n_steps_eval = 0\n",
-    "  eval_loss = 0\n",
-    "  val_iterator = validation_ds.as_numpy_iterator()\n",
-    "  for val_example in val_iterator:\n",
-    "    eval_loss += compiled_validation_step(model,\n",
-    "                                          params,\n",
-    "                                          dataset_builder._tokenizer.pad_id,\n",
-    "                                          val_example)\n",
-    "    n_steps_eval += 1\n",
-    "  print(f\"Start, validation loss: {eval_loss/n_steps_eval}\")\n",
-    "\n",
-    "  for train_example in train_ds:\n",
-    "    train_loss, params, opt_state = compiled_train_step(model=model,\n",
-    "                                                        params=params,\n",
-    "                                                        optimizer=optimizer,\n",
-    "                                                        opt_state=opt_state,\n",
-    "                                                        pad_id=dataset_builder._tokenizer.pad_id,\n",
-    "                                                        example=train_example)\n",
-    "    n_steps += 1\n",
-    "    avg_loss += train_loss\n",
-    "    if n_steps % training_cfg.eval_every_n == 0:\n",
-    "      eval_loss = 0\n",
-    "\n",
-    "      n_steps_eval = 0\n",
-    "      val_iterator = validation_ds.as_numpy_iterator()\n",
-    "      for val_example in val_iterator:\n",
-    "        eval_loss += compiled_validation_step(model,\n",
-    "                                              params,\n",
-    "                                              dataset_builder._tokenizer.pad_id,\n",
-    "                                              val_example)\n",
-    "        n_steps_eval +=1\n",
-    "      avg_loss /= training_cfg.eval_every_n\n",
-    "      eval_loss /= n_steps_eval\n",
-    "      print(f\"STEP {n_steps} training loss: {avg_loss} - eval loss: {eval_loss}\")\n",
-    "      avg_loss=0\n",
-    "    if training_cfg.max_steps is not None and n_steps > training_cfg.max_steps:\n",
-    "      break\n",
-    "  return params"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ecv6lp5MCzFc"
-   },
-   "source": [
-    "Begin fine-tuning the Gemma model on a limited number of steps (`SEQ_SIZE`) to make sure this fits in the memory:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "id": "7SL2VAmVEcoa"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Start, validation loss: 10.647212982177734\n",
-      "STEP 20 training loss: 3.3015992641448975 - eval loss: 2.686880111694336\n",
-      "STEP 40 training loss: 5.375057220458984 - eval loss: 2.6751961708068848\n",
-      "STEP 60 training loss: 2.6599338054656982 - eval loss: 2.663877010345459\n",
-      "STEP 80 training loss: 4.822389125823975 - eval loss: 2.3333375453948975\n",
-      "STEP 100 training loss: 2.0131142139434814 - eval loss: 2.360811948776245\n"
-     ]
-    }
-   ],
-   "source": [
-    "SEQ_SIZE = 25\n",
-    "tokenizer = GemmaTokenizer(vocab)\n",
-    "dataset_builder= MTNTDatasetBuilder(tokenizer, SEQ_SIZE)\n",
-    "training_cfg = TrainingConfig(learning_rate=1e-4,\n",
-    "                              num_epochs=1,\n",
-    "                              eval_every_n=20,\n",
-    "                              batch_size=1,\n",
-    "                              max_steps=100)\n",
-    "\n",
-    "params = train_loop(model=model_2b,\n",
-    "                    params={'params': params['transformer']},\n",
-    "                    dataset_builder=dataset_builder,\n",
-    "                    training_cfg=training_cfg)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "EtfVo3pDDAZV"
-   },
-   "source": [
-    "Both the training loss and the validation loss should have gone down with each step count.\n",
-    "\n",
-    "Create a `sampler` with [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/sampler.py#L88). It uses the Gemma model checkpoint and the tokenizer."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "id": "dQ1oCF10Ecod"
-   },
-   "outputs": [],
-   "source": [
-    "sampler = sampler_lib.Sampler(\n",
-    "    transformer=model_2b,\n",
-    "    vocab=vocab,\n",
-    "    params=params['params'],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-61KZz7EHiIS"
-   },
-   "source": [
-    "Use the `sampler` to check if your model can perform translation. The `total_generation_steps` argument in [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/sampler.py#L88) is the number of steps performed when generating a response. To ensure the input matches the training format, use the prefix `Translate this into French:\\n` with a newline character at the end. This signals the model to begin translation.\n",
-    "\n",
-    "**Note:** Due to hardware restrictions, the number of training parameters used in the gemma Transformer may not be sufficient to produce \"stable\" results in this demo.\n",
-    "\n",
-    "**Note:** If you run out of memory, click on **Runtime** > **Disconnect and delete runtime**, and then **Runtime** > **Run all**.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "id": "S5F3fk22Ecod"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[\"C'est Bonjour, mon nom est Morgane.C'est Bonjour, mon nom est Morgane.\"]"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sampler(\n",
-    "    [\"Translate this into French:\\nHello, my name is Morgane.\\n\"],\n",
-    "    total_generation_steps=100,\n",
-    "    ).text"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Jao0Qk-ZIqyD"
-   },
-   "source": [
-    "## Learn more\n",
-    "\n",
-    "- You can learn more about the Google DeepMind [`gemma`  library on GitHub](https://github.com/google-deepmind/gemma), which contains docstrings of modules you used in this tutorial, such as [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py),\n",
-    "[`gemma.transformer`](https://github.com/google-deepmind/gemma/blob/main/gemma/transformer.py), and\n",
-    "[`gemma.sampler`](https://github.com/google-deepmind/gemma/blob/main/gemma/sampler.py).\n",
-    "- The following libraries have their own documentation sites: [core JAX](https://jax.readthedocs.io), [Flax](https://flax.readthedocs.io), [Chex](https://chex.readthedocs.io/en/latest/), [Optax](https://optax.readthedocs.io/en/latest/), and [Orbax](https://orbax.readthedocs.io/).\n",
-    "- For `sentencepiece` tokenizer/detokenizer documentation, check out [Google's `sentencepiece` GitHub repo](https://github.com/google/sentencepiece).\n",
-    "- For `kagglehub` documentation, check out `README.md` on [Kaggle's `kagglehub` GitHub repo](https://github.com/Kaggle/kagglehub).\n",
-    "- Learn how to [use Gemma models with Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/open-models/use-gemma).\n",
-    "- If you are using Google Cloud TPUs (v3-8 and newer), make sure to also update to the latest `jax[tpu]` package (`!pip install -U jax[tpu] -f https://storage.googleapis.com/jax-releases/libtpu_releases.html`), restart the runtime, and check that `jax` and `jaxlib` versions match (`!pip list | grep jax`). This can prevent the `RuntimeError` that can arise because of the `jaxlib` and `jax` version mismatch. For more JAX installation instructions, refer to the [JAX docs](https://jax.readthedocs.io/en/latest/tutorials/installation.html#install-google-tpu)."
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "name": "jax_finetune.ipynb",
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/site/en/gemma/docs/jax_inference.ipynb
+++ b/site/en/gemma/docs/jax_inference.ipynb
@@ -1,513 +1,500 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Tce3stUlHN0L"
-   },
-   "source": [
-    "##### Copyright 2024 Google LLC."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "cellView": "form",
-    "id": "tuOe1ymfHZPu"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "FUOiKRSF7jc1"
-   },
-   "source": [
-    "# Inference with Gemma using JAX and Flax"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "60KmTK7o6ppd"
-   },
-   "source": [
-    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/jax_inference\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/google/generative-ai-docs/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://ai.google.dev/images/cloud-icon.svg\" width=\"40\" />Open in Vertex AI</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Tdlq6K0znh3O"
-   },
-   "source": [
-    "## Overview\n",
-    "\n",
-    "Gemma is a family of lightweight, state-of-the-art open large language models, based on the Google DeepMind Gemini research and technology. This tutorial demonstrates how to perform basic sampling/inference with the Gemma 2B Instruct model using [Google DeepMind's `gemma` library](https://github.com/google-deepmind/gemma) that was written with [JAX](https://jax.readthedocs.io) (a high-performance numerical computing library), [Flax](https://flax.readthedocs.io) (the JAX-based neural network library), [Orbax](https://orbax.readthedocs.io/) (a JAX-based library for training utilities like checkpointing), and [SentencePiece](https://github.com/google/sentencepiece) (a tokenizer/detokenizer library). Although Flax is not used directly in this notebook, Flax was used to create Gemma.\n",
-    "\n",
-    "This notebook can run on Google Colab with free T4 GPU (go to **Edit** > **Notebook settings** > Under **Hardware accelerator** select **T4 GPU**)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "aKvTsIkL98BG"
-   },
-   "source": [
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "WCgCkmQSPxkE"
-   },
-   "source": [
-    "### 1. Set up Kaggle access for Gemma\n",
-    "\n",
-    "To complete this tutorial, you first need to follow the setup instructions at [Gemma setup](https://ai.google.dev/gemma/docs/setup), which show you how to do the following:\n",
-    "\n",
-    "* Get access to Gemma on [kaggle.com](https://www.kaggle.com/models/google/gemma/).\n",
-    "* Select a Colab runtime with sufficient resources to run the Gemma model.\n",
-    "* Generate and configure a Kaggle username and API key.\n",
-    "\n",
-    "After you've completed the Gemma setup, move on to the next section, where you'll set environment variables for your Colab environment.\n",
-    "\n",
-    "### 2. Set environment variables\n",
-    "\n",
-    "Set environment variables for `KAGGLE_USERNAME` and `KAGGLE_KEY`. When prompted with the \"Grant access?\" messages, agree to provide secret access."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "id": "lKoW-nhE-gNO"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from google.colab import userdata # `userdata` is a Colab API.\n",
-    "\n",
-    "os.environ[\"KAGGLE_USERNAME\"] = userdata.get('KAGGLE_USERNAME')\n",
-    "os.environ[\"KAGGLE_KEY\"] = userdata.get('KAGGLE_KEY')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "AO7a1Q4Yyc9Z"
-   },
-   "source": [
-    "### 3. Install the `gemma` library\n",
-    "\n",
-    "This notebook focuses on using a free Colab GPU. To enable hardware acceleration, click on **Edit** > **Notebook settings** > Select **T4 GPU** > **Save**.\n",
-    "\n",
-    "Next, you need to install the Google DeepMind `gemma` library from [`github.com/google-deepmind/gemma`](https://github.com/google-deepmind/gemma). If you get an error about \"pip's dependency resolver\", you can usually ignore it.\n",
-    "\n",
-    "**Note:** By installing `gemma`, you will also install [`flax`](https://flax.readthedocs.io), core [`jax`](https://jax.readthedocs.io), [`optax`](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), [`orbax`](https://orbax.readthedocs.io/), and [`sentencepiece`](https://github.com/google/sentencepiece)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "id": "WWEzVJR4Fx9g"
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
-      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
-      "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.7/133.7 kB\u001b[0m \u001b[31m3.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.4/244.4 kB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h  Building wheel for gemma (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "tensorflow-metadata 1.14.0 requires absl-py<2.0.0,>=0.9, but you have absl-py 2.1.0 which is incompatible.\u001b[0m\u001b[31m\n",
-      "\u001b[0m"
-     ]
-    }
-   ],
-   "source": [
-    "!pip install -q git+https://github.com/google-deepmind/gemma.git"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "VKLjBAe1m3Ck"
-   },
-   "source": [
-    "## Load and prepare the Gemma model\n",
-    "\n",
-    "1. Load the Gemma model with [`kagglehub.model_download`](https://github.com/Kaggle/kagglehub/blob/bddefc718182282882b72f814d407d89e5d178c4/src/kagglehub/models.py#L12), which takes three arguments:\n",
-    "\n",
-    "- `handle`: The model handle from Kaggle\n",
-    "- `path`: (Optional string) The local path\n",
-    "- `force_download`: (Optional boolean) Forces to re-download the model\n",
-    "\n",
-    "**Note:** Be mindful that the `gemma-2b-it` model is around 3.7Gb in size."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "id": "_W3FUd9lt8VT"
-   },
-   "outputs": [],
-   "source": [
-    "GEMMA_VARIANT = '2b-it' # @param ['2b', '2b-it'] {type:\"string\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "id": "kFCmWEKdMA_Y"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Downloading from https://www.kaggle.com/api/v1/models/google/gemma/flax/2b-it/2/download...\n",
-      "100%|██████████| 3.67G/3.67G [00:35<00:00, 110MB/s]\n",
-      "Extracting model files...\n"
-     ]
-    }
-   ],
-   "source": [
-    "import kagglehub\n",
-    "\n",
-    "GEMMA_PATH = kagglehub.model_download(f'google/gemma/flax/{GEMMA_VARIANT}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "id": "nYmYTMk8aELi"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GEMMA_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2\n"
-     ]
-    }
-   ],
-   "source": [
-    "print('GEMMA_PATH:', GEMMA_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ytNi47xSlw71"
-   },
-   "source": [
-    "**Note:** The path from the output above is where the model weights and tokenizer are saved locally, you will need them for later."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "92BcvYdemXbd"
-   },
-   "source": [
-    "2. Check the location of the model weights and the tokenizer, then set the path variables. The tokenizer directory will be in the main directory where you downloaded the model, while the model weights will be in a sub-directory. For example:\n",
-    "\n",
-    "- The `tokenizer.model` file will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2`).\n",
-    "- The model checkpoint will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2/2b-it`)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "id": "QY6OnASOpZbW"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CKPT_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/2b-it\n",
-      "TOKENIZER_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/tokenizer.model\n"
-     ]
-    }
-   ],
-   "source": [
-    "CKPT_PATH = os.path.join(GEMMA_PATH, GEMMA_VARIANT)\n",
-    "TOKENIZER_PATH = os.path.join(GEMMA_PATH, 'tokenizer.model')\n",
-    "print('CKPT_PATH:', CKPT_PATH)\n",
-    "print('TOKENIZER_PATH:', TOKENIZER_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "jc0ZzYIW0TSN"
-   },
-   "source": [
-    "## Perform sampling/inference"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "aEe3p8geqekV"
-   },
-   "source": [
-    "1. Load and format the Gemma model checkpoint with the [`gemma.params.load_and_format_params`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/params.py#L27) method:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "id": "Mnr52JQVqKRw"
-   },
-   "outputs": [],
-   "source": [
-    "from gemma import params as params_lib\n",
-    "\n",
-    "params = params_lib.load_and_format_params(CKPT_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-Xpnb2igrGjk"
-   },
-   "source": [
-    "2. Load the Gemma tokenizer, constructed using [`sentencepiece.SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "id": "-T0ZHff5rNSy"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Tce3stUlHN0L"
+      },
+      "source": [
+        "##### Copyright 2024 Google LLC."
       ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import sentencepiece as spm\n",
-    "\n",
-    "vocab = spm.SentencePieceProcessor()\n",
-    "vocab.Load(TOKENIZER_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "IkAf4fkNrY-3"
-   },
-   "source": [
-    "3. To automatically load the correct configuration from the Gemma model checkpoint, use [`gemma.transformer.TransformerConfig`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L65). The `cache_size` argument is the number of time steps in the Gemma `Transformer` cache. Afterwards, instantiate the Gemma model as `transformer` with [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) (which inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html)).\n",
-    "\n",
-    "**Note:** The vocabulary size is smaller than the number of input embeddings because of unused tokens in the current Gemma release."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "id": "4PNWxDhvrRXJ"
-   },
-   "outputs": [],
-   "source": [
-    "from gemma import transformer as transformer_lib\n",
-    "\n",
-    "transformer_config = transformer_lib.TransformerConfig.from_params(\n",
-    "    params=params,\n",
-    "    cache_size=1024\n",
-    ")\n",
-    "\n",
-    "transformer = transformer_lib.Transformer(transformer_config)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "vs0vgmXVroBq"
-   },
-   "source": [
-    "3. Create a `sampler` with [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/sampler.py#L88) on top of the Gemma model checkpoint/weights and the tokenizer:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "id": "4GX4pFP6rtyN"
-   },
-   "outputs": [],
-   "source": [
-    "from gemma import sampler as sampler_lib\n",
-    "\n",
-    "sampler = sampler_lib.Sampler(\n",
-    "    transformer=transformer,\n",
-    "    vocab=vocab,\n",
-    "    params=params['transformer'],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "V9yU99Xxr59w"
-   },
-   "source": [
-    "4. Write a prompt in `input_batch` and perform inference. You can tweak `total_generation_steps` (the number of steps performed when generating a response — this example uses `100` to preserve host memory).\n",
-    "\n",
-    "**Note:** If you run out of memory, click on **Runtime** > **Disconnect and delete runtime**, and then **Runtime** > **Run all**."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "id": "Gj9jRFI5Hrv2"
-   },
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Prompt:\n",
-      "\n",
-      "# What is the meaning of life?\n",
-      "Output:\n",
-      "\n",
-      "\n",
-      "The question of what the meaning of life is one that has occupied the minds of philosophers, theologians, and individuals for centuries. There is no single, universally accepted answer, but there are many different perspectives on this complex and multifaceted question.\n",
-      "\n",
-      "**Some common perspectives on the meaning of life include:**\n",
-      "\n",
-      "* **Biological perspective:** From a biological standpoint, the meaning of life is to survive and reproduce.\n",
-      "* **Existential perspective:** Existentialists believe that life is not inherently meaningful and that\n"
-     ]
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "tuOe1ymfHZPu"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FUOiKRSF7jc1"
+      },
+      "source": [
+        "# Inference with Gemma using JAX and Flax"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "60KmTK7o6ppd"
+      },
+      "source": [
+        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/jax_inference\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/google/generative-ai-docs/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://ai.google.dev/images/cloud-icon.svg\" width=\"40\" />Open in Vertex AI</a>\n",
+        "  </td>\n",
+        "  <td>\n",
+        "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+        "  </td>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Tdlq6K0znh3O"
+      },
+      "source": [
+        "## Overview\n",
+        "\n",
+        "Gemma is a family of lightweight, state-of-the-art open large language models, based on the Google DeepMind Gemini research and technology. This tutorial demonstrates how to perform basic sampling/inference with the Gemma 2B Instruct model using [Google DeepMind's `gemma` library](https://github.com/google-deepmind/gemma) that was written with [JAX](https://jax.readthedocs.io) (a high-performance numerical computing library), [Flax](https://flax.readthedocs.io) (the JAX-based neural network library), [Orbax](https://orbax.readthedocs.io/) (a JAX-based library for training utilities like checkpointing), and [SentencePiece](https://github.com/google/sentencepiece) (a tokenizer/detokenizer library). Although Flax is not used directly in this notebook, Flax was used to create Gemma.\n",
+        "\n",
+        "This notebook can run on Google Colab with free T4 GPU (go to **Edit** > **Notebook settings** > Under **Hardware accelerator** select **T4 GPU**)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aKvTsIkL98BG"
+      },
+      "source": [
+        "## Setup"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WCgCkmQSPxkE"
+      },
+      "source": [
+        "### 1. Set up Kaggle access for Gemma\n",
+        "\n",
+        "To complete this tutorial, you first need to follow the setup instructions at [Gemma setup](https://ai.google.dev/gemma/docs/setup), which show you how to do the following:\n",
+        "\n",
+        "* Get access to Gemma on [kaggle.com](https://www.kaggle.com/models/google/gemma/).\n",
+        "* Select a Colab runtime with sufficient resources to run the Gemma model.\n",
+        "* Generate and configure a Kaggle username and API key.\n",
+        "\n",
+        "After you've completed the Gemma setup, move on to the next section, where you'll set environment variables for your Colab environment.\n",
+        "\n",
+        "### 2. Set environment variables\n",
+        "\n",
+        "Set environment variables for `KAGGLE_USERNAME` and `KAGGLE_KEY`. When prompted with the \"Grant access?\" messages, agree to provide secret access."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "lKoW-nhE-gNO"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from google.colab import userdata # `userdata` is a Colab API.\n",
+        "\n",
+        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get('KAGGLE_USERNAME')\n",
+        "os.environ[\"KAGGLE_KEY\"] = userdata.get('KAGGLE_KEY')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AO7a1Q4Yyc9Z"
+      },
+      "source": [
+        "### 3. Install the `gemma` library\n",
+        "\n",
+        "This notebook focuses on using a free Colab GPU. To enable hardware acceleration, click on **Edit** > **Notebook settings** > Select **T4 GPU** > **Save**.\n",
+        "\n",
+        "Next, you need to install the Google DeepMind `gemma` library from [`github.com/google-deepmind/gemma`](https://github.com/google-deepmind/gemma). If you get an error about \"pip's dependency resolver\", you can usually ignore it.\n",
+        "\n",
+        "**Note:** By installing `gemma`, you will also install [`flax`](https://flax.readthedocs.io), core [`jax`](https://jax.readthedocs.io), [`optax`](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), [`orbax`](https://orbax.readthedocs.io/), and [`sentencepiece`](https://github.com/google/sentencepiece)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "WWEzVJR4Fx9g"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.7/133.7 kB\u001b[0m \u001b[31m3.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.4/244.4 kB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h  Building wheel for gemma (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "tensorflow-metadata 1.14.0 requires absl-py<2.0.0,>=0.9, but you have absl-py 2.1.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0m"
+          ]
+        }
+      ],
+      "source": [
+        "!pip install -q git+https://github.com/google-deepmind/gemma.git"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VKLjBAe1m3Ck"
+      },
+      "source": [
+        "## Load and prepare the Gemma model\n",
+        "\n",
+        "1. Load the Gemma model with [`kagglehub.model_download`](https://github.com/Kaggle/kagglehub/blob/bddefc718182282882b72f814d407d89e5d178c4/src/kagglehub/models.py#L12), which takes three arguments:\n",
+        "\n",
+        "- `handle`: The model handle from Kaggle\n",
+        "- `path`: (Optional string) The local path\n",
+        "- `force_download`: (Optional boolean) Forces to re-download the model\n",
+        "\n",
+        "**Note:** Be mindful that the `gemma-2b-it` model is around 3.7Gb in size."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "_W3FUd9lt8VT"
+      },
+      "outputs": [],
+      "source": [
+        "GEMMA_VARIANT = '2b-it' # @param ['2b', '2b-it'] {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "kFCmWEKdMA_Y"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "Downloading from https://www.kaggle.com/api/v1/models/google/gemma/flax/2b-it/2/download...\n",
+            "100%|██████████| 3.67G/3.67G [00:35<00:00, 110MB/s]\n",
+            "Extracting model files...\n"
+          ]
+        }
+      ],
+      "source": [
+        "import kagglehub\n",
+        "\n",
+        "GEMMA_PATH = kagglehub.model_download(f'google/gemma/flax/{GEMMA_VARIANT}')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "id": "nYmYTMk8aELi"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "GEMMA_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2\n"
+          ]
+        }
+      ],
+      "source": [
+        "print('GEMMA_PATH:', GEMMA_PATH)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ytNi47xSlw71"
+      },
+      "source": [
+        "**Note:** The path from the output above is where the model weights and tokenizer are saved locally, you will need them for later."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "92BcvYdemXbd"
+      },
+      "source": [
+        "2. Check the location of the model weights and the tokenizer, then set the path variables. The tokenizer directory will be in the main directory where you downloaded the model, while the model weights will be in a sub-directory. For example:\n",
+        "\n",
+        "- The `tokenizer.model` file will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2`).\n",
+        "- The model checkpoint will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2/2b-it`)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "id": "QY6OnASOpZbW"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "CKPT_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/2b-it\n",
+            "TOKENIZER_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/tokenizer.model\n"
+          ]
+        }
+      ],
+      "source": [
+        "CKPT_PATH = os.path.join(GEMMA_PATH, GEMMA_VARIANT)\n",
+        "TOKENIZER_PATH = os.path.join(GEMMA_PATH, 'tokenizer.model')\n",
+        "print('CKPT_PATH:', CKPT_PATH)\n",
+        "print('TOKENIZER_PATH:', TOKENIZER_PATH)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "jc0ZzYIW0TSN"
+      },
+      "source": [
+        "## Perform sampling/inference"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aEe3p8geqekV"
+      },
+      "source": [
+        "1. Load and format the Gemma model checkpoint with the [`gemma.params.load_and_format_params`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/params.py#L27) method:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "id": "Mnr52JQVqKRw"
+      },
+      "outputs": [],
+      "source": [
+        "from gemma import params as params_lib\n",
+        "\n",
+        "params = params_lib.load_and_format_params(CKPT_PATH)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-Xpnb2igrGjk"
+      },
+      "source": [
+        "2. Load the Gemma tokenizer, constructed using [`sentencepiece.SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "id": "-T0ZHff5rNSy"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "True"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "import sentencepiece as spm\n",
+        "\n",
+        "vocab = spm.SentencePieceProcessor()\n",
+        "vocab.Load(TOKENIZER_PATH)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IkAf4fkNrY-3"
+      },
+      "source": [
+        "3. To automatically load the correct configuration from the Gemma model checkpoint, use [`gemma.transformer.TransformerConfig`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L65). The `cache_size` argument is the number of time steps in the Gemma `Transformer` cache. Afterwards, instantiate the Gemma model as `transformer` with [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) (which inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html)).\n",
+        "\n",
+        "**Note:** The vocabulary size is smaller than the number of input embeddings because of unused tokens in the current Gemma release."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "id": "4PNWxDhvrRXJ"
+      },
+      "outputs": [],
+      "source": [
+        "from gemma import transformer as transformer_lib\n",
+        "\n",
+        "transformer_config = transformer_lib.TransformerConfig.from_params(\n",
+        "    params=params,\n",
+        "    cache_size=1024\n",
+        ")\n",
+        "\n",
+        "transformer = transformer_lib.Transformer(transformer_config)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vs0vgmXVroBq"
+      },
+      "source": [
+        "3. Create a `sampler` with [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/sampler.py#L88) on top of the Gemma model checkpoint/weights and the tokenizer:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "id": "4GX4pFP6rtyN"
+      },
+      "outputs": [],
+      "source": [
+        "from gemma import sampler as sampler_lib\n",
+        "\n",
+        "sampler = sampler_lib.Sampler(\n",
+        "    transformer=transformer,\n",
+        "    vocab=vocab,\n",
+        "    params=params['transformer'],\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "V9yU99Xxr59w"
+      },
+      "source": [
+        "4. Write a prompt in `input_batch` and perform inference. You can tweak `total_generation_steps` (the number of steps performed when generating a response — this example uses `100` to preserve host memory).\n",
+        "\n",
+        "**Note:** If you run out of memory, click on **Runtime** > **Disconnect and delete runtime**, and then **Runtime** > **Run all**."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "id": "Gj9jRFI5Hrv2"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Prompt:\n",
+            "\n",
+            "# What is the meaning of life?\n",
+            "Output:\n",
+            "\n",
+            "\n",
+            "The question of what the meaning of life is one that has occupied the minds of philosophers, theologians, and individuals for centuries. There is no single, universally accepted answer, but there are many different perspectives on this complex and multifaceted question.\n",
+            "\n",
+            "**Some common perspectives on the meaning of life include:**\n",
+            "\n",
+            "* **Biological perspective:** From a biological standpoint, the meaning of life is to survive and reproduce.\n",
+            "* **Existential perspective:** Existentialists believe that life is not inherently meaningful and that\n"
+          ]
+        }
+      ],
+      "source": [
+        "prompt = [\n",
+        "    \"\\n# What is the meaning of life?\",\n",
+        "]\n",
+        "\n",
+        "reply = sampler(input_strings=prompt,\n",
+        "                total_generation_steps=100,\n",
+        "                )\n",
+        "\n",
+        "for input_string, out_string in zip(prompt, reply.text):\n",
+        "    print(f\"Prompt:\\n{input_string}\\nOutput:\\n{out_string}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "njxRJy3qsBWw"
+      },
+      "source": [
+        "5. (Optional) Run this cell to free up memory if you have completed the notebook and want to try another prompt. Afterwards, you can instantiate the `sampler` again in step 3 and customize and run the prompt in step 4."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qxX6qfFdNGHy"
+      },
+      "outputs": [],
+      "source": [
+        "del sampler"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bzKsCGIN0yX5"
+      },
+      "source": [
+        "## Learn more\n",
+        "\n",
+        "- You can learn more about the Google DeepMind [`gemma`  library on GitHub](https://github.com/google-deepmind/gemma), which contains docstrings of modules you used in this tutorial, such as [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py),\n",
+        "[`gemma.transformer`](https://github.com/google-deepmind/gemma/blob/main/gemma/transformer.py), and\n",
+        "[`gemma.sampler`](https://github.com/google-deepmind/gemma/blob/main/gemma/sampler.py).\n",
+        "- The following libraries have their own documentation sites: [core JAX](https://jax.readthedocs.io), [Flax](https://flax.readthedocs.io), and [Orbax](https://orbax.readthedocs.io/).\n",
+        "- For `sentencepiece` tokenizer/detokenizer documentation, check out [Google's `sentencepiece` GitHub repo](https://github.com/google/sentencepiece).\n",
+        "- For `kagglehub` documentation, check out `README.md` on [Kaggle's `kagglehub` GitHub repo](https://github.com/Kaggle/kagglehub).\n",
+        "- Learn how to [use Gemma models with Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/open-models/use-gemma)."
+      ]
     }
-   ],
-   "source": [
-    "prompt = [\n",
-    "    \"\\n# What is the meaning of life?\",\n",
-    "]\n",
-    "\n",
-    "reply = sampler(input_strings=prompt,\n",
-    "                total_generation_steps=100,\n",
-    "                )\n",
-    "\n",
-    "for input_string, out_string in zip(prompt, reply.text):\n",
-    "    print(f\"Prompt:\\n{input_string}\\nOutput:\\n{out_string}\")"
-   ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "jax_inference.ipynb",
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "njxRJy3qsBWw"
-   },
-   "source": [
-    "5. (Optional) Run this cell to free up memory if you have completed the notebook and want to try another prompt. Afterwards, you can instantiate the `sampler` again in step 3 and customize and run the prompt in step 4."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "qxX6qfFdNGHy"
-   },
-   "outputs": [],
-   "source": [
-    "del sampler"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "bzKsCGIN0yX5"
-   },
-   "source": [
-    "## Learn more\n",
-    "\n",
-    "- You can learn more about the Google DeepMind [`gemma`  library on GitHub](https://github.com/google-deepmind/gemma), which contains docstrings of modules you used in this tutorial, such as [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py),\n",
-    "[`gemma.transformer`](https://github.com/google-deepmind/gemma/blob/main/gemma/transformer.py), and\n",
-    "[`gemma.sampler`](https://github.com/google-deepmind/gemma/blob/main/gemma/sampler.py).\n",
-    "- The following libraries have their own documentation sites: [core JAX](https://jax.readthedocs.io), [Flax](https://flax.readthedocs.io), and [Orbax](https://orbax.readthedocs.io/).\n",
-    "- For `sentencepiece` tokenizer/detokenizer documentation, check out [Google's `sentencepiece` GitHub repo](https://github.com/google/sentencepiece).\n",
-    "- For `kagglehub` documentation, check out `README.md` on [Kaggle's `kagglehub` GitHub repo](https://github.com/Kaggle/kagglehub).\n",
-    "- Learn how to [use Gemma models with Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/open-models/use-gemma)."
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "name": "jax_inference.ipynb",
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/site/en/gemma/docs/jax_inference.ipynb
+++ b/site/en/gemma/docs/jax_inference.ipynb
@@ -1,500 +1,513 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Tce3stUlHN0L"
-      },
-      "source": [
-        "##### Copyright 2024 Google LLC."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "cellView": "form",
-        "id": "tuOe1ymfHZPu"
-      },
-      "outputs": [],
-      "source": [
-        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FUOiKRSF7jc1"
-      },
-      "source": [
-        "# Inference with Gemma using JAX and Flax"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "60KmTK7o6ppd"
-      },
-      "source": [
-        "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/jax_inference\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/google/generative-ai-docs/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://ai.google.dev/images/cloud-icon.svg\" width=\"40\" />Open in Vertex AI</a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-        "  </td>\n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Tdlq6K0znh3O"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "Gemma is a family of lightweight, state-of-the-art open large language models, based on the Google DeepMind Gemini research and technology. This tutorial demonstrates how to perform basic sampling/inference with the Gemma 2B Instruct model using [Google DeepMind's `gemma` library](https://github.com/google-deepmind/gemma) that was written with [JAX](https://jax.readthedocs.io) (a high-performance numerical computing library), [Flax](https://flax.readthedocs.io) (the JAX-based neural network library), [Orbax](https://orbax.readthedocs.io/) (a JAX-based library for training utilities like checkpointing), and [SentencePiece](https://github.com/google/sentencepiece) (a tokenizer/detokenizer library). Although Flax is not used directly in this notebook, Flax was used to create Gemma.\n",
-        "\n",
-        "This notebook can run on Google Colab with free T4 GPU (go to **Edit** > **Notebook settings** > Under **Hardware accelerator** select **T4 GPU**)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aKvTsIkL98BG"
-      },
-      "source": [
-        "## Setup"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WCgCkmQSPxkE"
-      },
-      "source": [
-        "### 1. Set up Kaggle access for Gemma\n",
-        "\n",
-        "To complete this tutorial, you first need to follow the setup instructions at [Gemma setup](https://ai.google.dev/gemma/docs/setup), which show you how to do the following:\n",
-        "\n",
-        "* Get access to Gemma on [kaggle.com](https://www.kaggle.com/models/google/gemma/).\n",
-        "* Select a Colab runtime with sufficient resources to run the Gemma model.\n",
-        "* Generate and configure a Kaggle username and API key.\n",
-        "\n",
-        "After you've completed the Gemma setup, move on to the next section, where you'll set environment variables for your Colab environment.\n",
-        "\n",
-        "### Set environment variables\n",
-        "\n",
-        "Set environment variables for `KAGGLE_USERNAME` and `KAGGLE_KEY`. When prompted with the \"Grant access?\" messages, agree to provide secret access."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "lKoW-nhE-gNO"
-      },
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "from google.colab import userdata # `userdata` is a Colab API.\n",
-        "\n",
-        "os.environ[\"KAGGLE_USERNAME\"] = userdata.get('KAGGLE_USERNAME')\n",
-        "os.environ[\"KAGGLE_KEY\"] = userdata.get('KAGGLE_KEY')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "AO7a1Q4Yyc9Z"
-      },
-      "source": [
-        "### 2. Install the `gemma` library\n",
-        "\n",
-        "This notebook focuses on using a free Colab GPU. To enable hardware acceleration, click on **Edit** > **Notebook settings** > Select **T4 GPU** > **Save**.\n",
-        "\n",
-        "Next, you need to install the Google DeepMind `gemma` library from [`github.com/google-deepmind/gemma`](https://github.com/google-deepmind/gemma). If you get an error about \"pip's dependency resolver\", you can usually ignore it.\n",
-        "\n",
-        "**Note:** By installing `gemma`, you will also install [`flax`](https://flax.readthedocs.io), core [`jax`](https://jax.readthedocs.io), [`optax`](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), [`orbax`](https://orbax.readthedocs.io/), and [`sentencepiece`](https://github.com/google/sentencepiece)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "id": "WWEzVJR4Fx9g"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
-            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
-            "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.7/133.7 kB\u001b[0m \u001b[31m3.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.4/244.4 kB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25h  Building wheel for gemma (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-            "tensorflow-metadata 1.14.0 requires absl-py<2.0.0,>=0.9, but you have absl-py 2.1.0 which is incompatible.\u001b[0m\u001b[31m\n",
-            "\u001b[0m"
-          ]
-        }
-      ],
-      "source": [
-        "!pip install -q git+https://github.com/google-deepmind/gemma.git"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VKLjBAe1m3Ck"
-      },
-      "source": [
-        "## Load and prepare the Gemma model\n",
-        "\n",
-        "1. Load the Gemma model with [`kagglehub.model_download`](https://github.com/Kaggle/kagglehub/blob/bddefc718182282882b72f814d407d89e5d178c4/src/kagglehub/models.py#L12), which takes three arguments:\n",
-        "\n",
-        "- `handle`: The model handle from Kaggle\n",
-        "- `path`: (Optional string) The local path\n",
-        "- `force_download`: (Optional boolean) Forces to re-download the model\n",
-        "\n",
-        "**Note:** Be mindful that the `gemma-2b-it` model is around 3.7Gb in size."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "id": "_W3FUd9lt8VT"
-      },
-      "outputs": [],
-      "source": [
-        "GEMMA_VARIANT = '2b-it' # @param ['2b', '2b-it'] {type:\"string\"}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "id": "kFCmWEKdMA_Y"
-      },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "Downloading from https://www.kaggle.com/api/v1/models/google/gemma/flax/2b-it/2/download...\n",
-            "100%|██████████| 3.67G/3.67G [00:35<00:00, 110MB/s]\n",
-            "Extracting model files...\n"
-          ]
-        }
-      ],
-      "source": [
-        "import kagglehub\n",
-        "\n",
-        "GEMMA_PATH = kagglehub.model_download(f'google/gemma/flax/{GEMMA_VARIANT}')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "id": "nYmYTMk8aELi"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "GEMMA_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2\n"
-          ]
-        }
-      ],
-      "source": [
-        "print('GEMMA_PATH:', GEMMA_PATH)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ytNi47xSlw71"
-      },
-      "source": [
-        "**Note:** The path from the output above is where the model weights and tokenizer are saved locally, you will need them for later."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "92BcvYdemXbd"
-      },
-      "source": [
-        "2. Check the location of the model weights and the tokenizer, then set the path variables. The tokenizer directory will be in the main directory where you downloaded the model, while the model weights will be in a sub-directory. For example:\n",
-        "\n",
-        "- The `tokenizer.model` file will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2`).\n",
-        "- The model checkpoint will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2/2b-it`)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "id": "QY6OnASOpZbW"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CKPT_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/2b-it\n",
-            "TOKENIZER_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/tokenizer.model\n"
-          ]
-        }
-      ],
-      "source": [
-        "CKPT_PATH = os.path.join(GEMMA_PATH, GEMMA_VARIANT)\n",
-        "TOKENIZER_PATH = os.path.join(GEMMA_PATH, 'tokenizer.model')\n",
-        "print('CKPT_PATH:', CKPT_PATH)\n",
-        "print('TOKENIZER_PATH:', TOKENIZER_PATH)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jc0ZzYIW0TSN"
-      },
-      "source": [
-        "## Perform sampling/inference"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aEe3p8geqekV"
-      },
-      "source": [
-        "1. Load and format the Gemma model checkpoint with the [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py) method:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "id": "Mnr52JQVqKRw"
-      },
-      "outputs": [],
-      "source": [
-        "from gemma import params as params_lib\n",
-        "\n",
-        "params = params_lib.load_and_format_params(CKPT_PATH)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "-Xpnb2igrGjk"
-      },
-      "source": [
-        "2. Load the Gemma tokenizer, constructed using [`sentencepiece.SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "id": "-T0ZHff5rNSy"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "True"
-            ]
-          },
-          "execution_count": 8,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "import sentencepiece as spm\n",
-        "\n",
-        "vocab = spm.SentencePieceProcessor()\n",
-        "vocab.Load(TOKENIZER_PATH)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "IkAf4fkNrY-3"
-      },
-      "source": [
-        "3. To automatically load the correct configuration from the Gemma model checkpoint, use [`gemma.transformer.TransformerConfig`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L65). The `cache_size` argument is the number of time steps in the Gemma `transformer` cache. Afterwards, instantiate the Gemma model as `transformer` with [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) (which inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html)).\n",
-        "\n",
-        "**Note:** The vocabulary size is smaller than the number of input embeddings because of unused tokens in the current Gemma release."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "id": "4PNWxDhvrRXJ"
-      },
-      "outputs": [],
-      "source": [
-        "from gemma import transformer as transformer_lib\n",
-        "\n",
-        "transformer_config = transformer_lib.TransformerConfig.from_params(\n",
-        "    params=params,\n",
-        "    cache_size=1024\n",
-        ")\n",
-        "\n",
-        "transformer = transformer_lib.Transformer(transformer_config)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vs0vgmXVroBq"
-      },
-      "source": [
-        "3. Create a `sampler` with [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/sampler.py#L88) on top of the Gemma model checkpoint/weights and the tokenizer:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "id": "4GX4pFP6rtyN"
-      },
-      "outputs": [],
-      "source": [
-        "from gemma import sampler as sampler_lib\n",
-        "\n",
-        "sampler = sampler_lib.Sampler(\n",
-        "    transformer=transformer,\n",
-        "    vocab=vocab,\n",
-        "    params=params['transformer'],\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "V9yU99Xxr59w"
-      },
-      "source": [
-        "4. Write a prompt in `input_batch` and perform inference. You can tweak `total_generation_steps` (the number of steps performed when generating a response — this example uses `100` to preserve host memory).\n",
-        "\n",
-        "**Note:** If you run out of memory, click on **Runtime** > **Disconnect and delete runtime**, and then **Runtime** > **Run all**."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {
-        "id": "Gj9jRFI5Hrv2"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Prompt:\n",
-            "\n",
-            "# What is the meaning of life?\n",
-            "Output:\n",
-            "\n",
-            "\n",
-            "The question of what the meaning of life is one that has occupied the minds of philosophers, theologians, and individuals for centuries. There is no single, universally accepted answer, but there are many different perspectives on this complex and multifaceted question.\n",
-            "\n",
-            "**Some common perspectives on the meaning of life include:**\n",
-            "\n",
-            "* **Biological perspective:** From a biological standpoint, the meaning of life is to survive and reproduce.\n",
-            "* **Existential perspective:** Existentialists believe that life is not inherently meaningful and that\n"
-          ]
-        }
-      ],
-      "source": [
-        "prompt = [\n",
-        "    \"\\n# What is the meaning of life?\",\n",
-        "]\n",
-        "\n",
-        "reply = sampler(input_strings=prompt,\n",
-        "                total_generation_steps=100,\n",
-        "                )\n",
-        "\n",
-        "for input_string, out_string in zip(prompt, reply.text):\n",
-        "    print(f\"Prompt:\\n{input_string}\\nOutput:\\n{out_string}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "njxRJy3qsBWw"
-      },
-      "source": [
-        "5. (Option) Run this cell to free up memory if you have completed the notebook and want to try another prompt. Afterwards, you can instantiate the `sampler` again in step 3 and customize and run the prompt in step 4."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qxX6qfFdNGHy"
-      },
-      "outputs": [],
-      "source": [
-        "del sampler"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bzKsCGIN0yX5"
-      },
-      "source": [
-        "## Learn more\n",
-        "\n",
-        "- You can learn more about the Google DeepMind [`gemma`  library on GitHub](https://github.com/google-deepmind/gemma), which contains docstrings of methods you used in this tutorial, such as [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py),\n",
-        "[`gemma.transformer`](https://github.com/google-deepmind/gemma/blob/main/gemma/transformer.py), and\n",
-        "[`gemma.sampler`](https://github.com/google-deepmind/gemma/blob/main/gemma/sampler.py).\n",
-        "- The following libraries have their own documentation sites: [core JAX](https://jax.readthedocs.io), [Flax](https://flax.readthedocs.io), and [Orbax](https://orbax.readthedocs.io/).\n",
-        "- For `sentencepiece` tokenizer/detokenizer documentation, check out [Google's `sentencepiece` GitHub repo](https://github.com/google/sentencepiece).\n",
-        "- For `kagglehub` documentation, check out `README.md` on [Kaggle's `kagglehub` GitHub repo](https://github.com/Kaggle/kagglehub).\n",
-        "- Learn how to [use Gemma models with Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/open-models/use-gemma)."
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "jax_inference.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Tce3stUlHN0L"
+   },
+   "source": [
+    "##### Copyright 2024 Google LLC."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form",
+    "id": "tuOe1ymfHZPu"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FUOiKRSF7jc1"
+   },
+   "source": [
+    "# Inference with Gemma using JAX and Flax"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "60KmTK7o6ppd"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/jax_inference\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/google/generative-ai-docs/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://ai.google.dev/images/cloud-icon.svg\" width=\"40\" />Open in Vertex AI</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/google/generative-ai-docs/blob/main/site/en/gemma/docs/jax_inference.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Tdlq6K0znh3O"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "Gemma is a family of lightweight, state-of-the-art open large language models, based on the Google DeepMind Gemini research and technology. This tutorial demonstrates how to perform basic sampling/inference with the Gemma 2B Instruct model using [Google DeepMind's `gemma` library](https://github.com/google-deepmind/gemma) that was written with [JAX](https://jax.readthedocs.io) (a high-performance numerical computing library), [Flax](https://flax.readthedocs.io) (the JAX-based neural network library), [Orbax](https://orbax.readthedocs.io/) (a JAX-based library for training utilities like checkpointing), and [SentencePiece](https://github.com/google/sentencepiece) (a tokenizer/detokenizer library). Although Flax is not used directly in this notebook, Flax was used to create Gemma.\n",
+    "\n",
+    "This notebook can run on Google Colab with free T4 GPU (go to **Edit** > **Notebook settings** > Under **Hardware accelerator** select **T4 GPU**)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aKvTsIkL98BG"
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WCgCkmQSPxkE"
+   },
+   "source": [
+    "### 1. Set up Kaggle access for Gemma\n",
+    "\n",
+    "To complete this tutorial, you first need to follow the setup instructions at [Gemma setup](https://ai.google.dev/gemma/docs/setup), which show you how to do the following:\n",
+    "\n",
+    "* Get access to Gemma on [kaggle.com](https://www.kaggle.com/models/google/gemma/).\n",
+    "* Select a Colab runtime with sufficient resources to run the Gemma model.\n",
+    "* Generate and configure a Kaggle username and API key.\n",
+    "\n",
+    "After you've completed the Gemma setup, move on to the next section, where you'll set environment variables for your Colab environment.\n",
+    "\n",
+    "### 2. Set environment variables\n",
+    "\n",
+    "Set environment variables for `KAGGLE_USERNAME` and `KAGGLE_KEY`. When prompted with the \"Grant access?\" messages, agree to provide secret access."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "lKoW-nhE-gNO"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from google.colab import userdata # `userdata` is a Colab API.\n",
+    "\n",
+    "os.environ[\"KAGGLE_USERNAME\"] = userdata.get('KAGGLE_USERNAME')\n",
+    "os.environ[\"KAGGLE_KEY\"] = userdata.get('KAGGLE_KEY')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AO7a1Q4Yyc9Z"
+   },
+   "source": [
+    "### 3. Install the `gemma` library\n",
+    "\n",
+    "This notebook focuses on using a free Colab GPU. To enable hardware acceleration, click on **Edit** > **Notebook settings** > Select **T4 GPU** > **Save**.\n",
+    "\n",
+    "Next, you need to install the Google DeepMind `gemma` library from [`github.com/google-deepmind/gemma`](https://github.com/google-deepmind/gemma). If you get an error about \"pip's dependency resolver\", you can usually ignore it.\n",
+    "\n",
+    "**Note:** By installing `gemma`, you will also install [`flax`](https://flax.readthedocs.io), core [`jax`](https://jax.readthedocs.io), [`optax`](https://optax.readthedocs.io/en/latest/) (the JAX-based gradient processing and optimization library), [`orbax`](https://orbax.readthedocs.io/), and [`sentencepiece`](https://github.com/google/sentencepiece)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "WWEzVJR4Fx9g"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+      "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m133.7/133.7 kB\u001b[0m \u001b[31m3.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m244.4/244.4 kB\u001b[0m \u001b[31m13.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25h  Building wheel for gemma (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
+      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "tensorflow-metadata 1.14.0 requires absl-py<2.0.0,>=0.9, but you have absl-py 2.1.0 which is incompatible.\u001b[0m\u001b[31m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install -q git+https://github.com/google-deepmind/gemma.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VKLjBAe1m3Ck"
+   },
+   "source": [
+    "## Load and prepare the Gemma model\n",
+    "\n",
+    "1. Load the Gemma model with [`kagglehub.model_download`](https://github.com/Kaggle/kagglehub/blob/bddefc718182282882b72f814d407d89e5d178c4/src/kagglehub/models.py#L12), which takes three arguments:\n",
+    "\n",
+    "- `handle`: The model handle from Kaggle\n",
+    "- `path`: (Optional string) The local path\n",
+    "- `force_download`: (Optional boolean) Forces to re-download the model\n",
+    "\n",
+    "**Note:** Be mindful that the `gemma-2b-it` model is around 3.7Gb in size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "_W3FUd9lt8VT"
+   },
+   "outputs": [],
+   "source": [
+    "GEMMA_VARIANT = '2b-it' # @param ['2b', '2b-it'] {type:\"string\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "id": "kFCmWEKdMA_Y"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading from https://www.kaggle.com/api/v1/models/google/gemma/flax/2b-it/2/download...\n",
+      "100%|██████████| 3.67G/3.67G [00:35<00:00, 110MB/s]\n",
+      "Extracting model files...\n"
+     ]
+    }
+   ],
+   "source": [
+    "import kagglehub\n",
+    "\n",
+    "GEMMA_PATH = kagglehub.model_download(f'google/gemma/flax/{GEMMA_VARIANT}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "id": "nYmYTMk8aELi"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GEMMA_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('GEMMA_PATH:', GEMMA_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ytNi47xSlw71"
+   },
+   "source": [
+    "**Note:** The path from the output above is where the model weights and tokenizer are saved locally, you will need them for later."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "92BcvYdemXbd"
+   },
+   "source": [
+    "2. Check the location of the model weights and the tokenizer, then set the path variables. The tokenizer directory will be in the main directory where you downloaded the model, while the model weights will be in a sub-directory. For example:\n",
+    "\n",
+    "- The `tokenizer.model` file will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2`).\n",
+    "- The model checkpoint will be in `/LOCAL/PATH/TO/gemma/flax/2b-it/2/2b-it`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "QY6OnASOpZbW"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CKPT_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/2b-it\n",
+      "TOKENIZER_PATH: /root/.cache/kagglehub/models/google/gemma/flax/2b-it/2/tokenizer.model\n"
+     ]
+    }
+   ],
+   "source": [
+    "CKPT_PATH = os.path.join(GEMMA_PATH, GEMMA_VARIANT)\n",
+    "TOKENIZER_PATH = os.path.join(GEMMA_PATH, 'tokenizer.model')\n",
+    "print('CKPT_PATH:', CKPT_PATH)\n",
+    "print('TOKENIZER_PATH:', TOKENIZER_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jc0ZzYIW0TSN"
+   },
+   "source": [
+    "## Perform sampling/inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aEe3p8geqekV"
+   },
+   "source": [
+    "1. Load and format the Gemma model checkpoint with the [`gemma.params.load_and_format_params`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/params.py#L27) method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "Mnr52JQVqKRw"
+   },
+   "outputs": [],
+   "source": [
+    "from gemma import params as params_lib\n",
+    "\n",
+    "params = params_lib.load_and_format_params(CKPT_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-Xpnb2igrGjk"
+   },
+   "source": [
+    "2. Load the Gemma tokenizer, constructed using [`sentencepiece.SentencePieceProcessor`](https://github.com/google/sentencepiece/blob/4d6a1f41069c4636c51a5590f7578a0dbed83450/python/src/sentencepiece/__init__.py#L423):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "-T0ZHff5rNSy"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sentencepiece as spm\n",
+    "\n",
+    "vocab = spm.SentencePieceProcessor()\n",
+    "vocab.Load(TOKENIZER_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "IkAf4fkNrY-3"
+   },
+   "source": [
+    "3. To automatically load the correct configuration from the Gemma model checkpoint, use [`gemma.transformer.TransformerConfig`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L65). The `cache_size` argument is the number of time steps in the Gemma `Transformer` cache. Afterwards, instantiate the Gemma model as `transformer` with [`gemma.transformer.Transformer`](https://github.com/google-deepmind/gemma/blob/56e501ce147af4ea5c23cc0ddf5a9c4a6b7bd0d0/gemma/transformer.py#L136) (which inherits from [`flax.linen.Module`](https://flax.readthedocs.io/en/latest/api_reference/flax.linen/module.html)).\n",
+    "\n",
+    "**Note:** The vocabulary size is smaller than the number of input embeddings because of unused tokens in the current Gemma release."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "4PNWxDhvrRXJ"
+   },
+   "outputs": [],
+   "source": [
+    "from gemma import transformer as transformer_lib\n",
+    "\n",
+    "transformer_config = transformer_lib.TransformerConfig.from_params(\n",
+    "    params=params,\n",
+    "    cache_size=1024\n",
+    ")\n",
+    "\n",
+    "transformer = transformer_lib.Transformer(transformer_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vs0vgmXVroBq"
+   },
+   "source": [
+    "3. Create a `sampler` with [`gemma.sampler.Sampler`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/sampler.py#L88) on top of the Gemma model checkpoint/weights and the tokenizer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "4GX4pFP6rtyN"
+   },
+   "outputs": [],
+   "source": [
+    "from gemma import sampler as sampler_lib\n",
+    "\n",
+    "sampler = sampler_lib.Sampler(\n",
+    "    transformer=transformer,\n",
+    "    vocab=vocab,\n",
+    "    params=params['transformer'],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "V9yU99Xxr59w"
+   },
+   "source": [
+    "4. Write a prompt in `input_batch` and perform inference. You can tweak `total_generation_steps` (the number of steps performed when generating a response — this example uses `100` to preserve host memory).\n",
+    "\n",
+    "**Note:** If you run out of memory, click on **Runtime** > **Disconnect and delete runtime**, and then **Runtime** > **Run all**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "id": "Gj9jRFI5Hrv2"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prompt:\n",
+      "\n",
+      "# What is the meaning of life?\n",
+      "Output:\n",
+      "\n",
+      "\n",
+      "The question of what the meaning of life is one that has occupied the minds of philosophers, theologians, and individuals for centuries. There is no single, universally accepted answer, but there are many different perspectives on this complex and multifaceted question.\n",
+      "\n",
+      "**Some common perspectives on the meaning of life include:**\n",
+      "\n",
+      "* **Biological perspective:** From a biological standpoint, the meaning of life is to survive and reproduce.\n",
+      "* **Existential perspective:** Existentialists believe that life is not inherently meaningful and that\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt = [\n",
+    "    \"\\n# What is the meaning of life?\",\n",
+    "]\n",
+    "\n",
+    "reply = sampler(input_strings=prompt,\n",
+    "                total_generation_steps=100,\n",
+    "                )\n",
+    "\n",
+    "for input_string, out_string in zip(prompt, reply.text):\n",
+    "    print(f\"Prompt:\\n{input_string}\\nOutput:\\n{out_string}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "njxRJy3qsBWw"
+   },
+   "source": [
+    "5. (Optional) Run this cell to free up memory if you have completed the notebook and want to try another prompt. Afterwards, you can instantiate the `sampler` again in step 3 and customize and run the prompt in step 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qxX6qfFdNGHy"
+   },
+   "outputs": [],
+   "source": [
+    "del sampler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bzKsCGIN0yX5"
+   },
+   "source": [
+    "## Learn more\n",
+    "\n",
+    "- You can learn more about the Google DeepMind [`gemma`  library on GitHub](https://github.com/google-deepmind/gemma), which contains docstrings of modules you used in this tutorial, such as [`gemma.params`](https://github.com/google-deepmind/gemma/blob/main/gemma/params.py),\n",
+    "[`gemma.transformer`](https://github.com/google-deepmind/gemma/blob/main/gemma/transformer.py), and\n",
+    "[`gemma.sampler`](https://github.com/google-deepmind/gemma/blob/main/gemma/sampler.py).\n",
+    "- The following libraries have their own documentation sites: [core JAX](https://jax.readthedocs.io), [Flax](https://flax.readthedocs.io), and [Orbax](https://orbax.readthedocs.io/).\n",
+    "- For `sentencepiece` tokenizer/detokenizer documentation, check out [Google's `sentencepiece` GitHub repo](https://github.com/google/sentencepiece).\n",
+    "- For `kagglehub` documentation, check out `README.md` on [Kaggle's `kagglehub` GitHub repo](https://github.com/Kaggle/kagglehub).\n",
+    "- Learn how to [use Gemma models with Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/docs/generative-ai/open-models/use-gemma)."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "name": "jax_inference.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
@pcoet @markmcd @MarkDaoust PTAL

- In Fine-tuning notebook - under "Learn more" -> use "modules" instead of "methods".
- Add a link to [`gemma.params.load_and_format`](https://github.com/google-deepmind/gemma/blob/c6bd156c246530e1620a7c62de98542a377e3934/gemma/params.py#L27).
- Add a missing number ("2. Set environment variables") in the "Setup" section.
- Gemma `transformer` -> Gemma `Transformer` (class).
- Fix a missing `)`.