### PR TITLE
reverse order of import and backend steps

### DIFF
--- a/site/en/gemma/docs/get_started.ipynb
+++ b/site/en/gemma/docs/get_started.ipynb
@@ -148,29 +148,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "FX47AUYrXwLK"
-      },
-      "source": [
-        "### Import packages\n",
-        "\n",
-        "Import Keras and KerasNLP."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ww83zI9ToPso"
-      },
-      "outputs": [],
-      "source": [
-        "import keras\n",
-        "import keras_nlp"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "Pm5cVOFt5YvZ"
       },
       "source": [
@@ -190,6 +167,25 @@
         "import os\n",
         "\n",
         "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # Or \"tensorflow\" or \"torch\"."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Import packages\n",
+        "\n",
+        "Import Keras and KerasNLP."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import keras\n",
+        "import keras_nlp"
       ]
     },
     {

--- a/site/en/gemma/docs/get_started.ipynb
+++ b/site/en/gemma/docs/get_started.ipynb
@@ -171,7 +171,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "599765c72722"
+      },
       "source": [
         "### Import packages\n",
         "\n",
@@ -181,7 +183,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "f2fa267d75bc"
+      },
       "outputs": [],
       "source": [
         "import keras\n",


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->

Reversed the order of two steps in the Gemma quickstart: you need to set the backend before importing packages.

## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->

If you don't set the backend env var first, the backend choice won't take effect.

## Type of change
Choose one: (Bug fix | Feature request | Documentation | Other)

Bug fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
