### PR TITLE
Update get_started.ipynb

### DIFF
--- a/site/en/gemma/docs/get_started.ipynb
+++ b/site/en/gemma/docs/get_started.ipynb
@@ -167,6 +167,8 @@
         "import os\n",
         "\n",
         "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # Or \"tensorflow\" or \"torch\"."
+        "\n",
+        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \"0.9\"
       ]
     },
     {

--- a/site/en/gemma/docs/get_started.ipynb
+++ b/site/en/gemma/docs/get_started.ipynb
@@ -166,9 +166,8 @@
       "source": [
         "import os\n",
         "\n",
-        "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # Or \"tensorflow\" or \"torch\"."
-        "\n",
-        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \"0.9\"
+        "os.environ[\"KERAS_BACKEND\"] = \"jax\"  # Or \"tensorflow\" or \"torch\".\n",
+        "os.environ[\"XLA_PYTHON_CLIENT_MEM_FRACTION\"] = \"0.9\""
       ]
     },
     {


### PR DESCRIPTION


## Description of the change
Pre-allocate 90% of TPU memory to minimize memory fragmentation and allocation overhead in Gemma getting started tutorial

## Motivation
otherwise it OOMs when batching 2 prompts on Colab T4.

## Type of change
Choose one: doc

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [ ] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [ ] I have verified that my change does not break existing code.
- [ ] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
