### PR TITLE
Add outputs to site notebooks.

### DIFF
--- a/site/en/gemini-api/docs/semantic_retrieval.ipynb
+++ b/site/en/gemini-api/docs/semantic_retrieval.ipynb
@@ -218,7 +218,25 @@
       "metadata": {
         "id": "AaPZiXVwEDHZ"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "name: \"corpora/google-for-developers-blog-dqrtz8rs0jg\"\n",
+            "display_name: \"Google for Developers Blog\"\n",
+            "create_time {\n",
+            "  seconds: 1713497533\n",
+            "  nanos: 587977000\n",
+            "}\n",
+            "update_time {\n",
+            "  seconds: 1713497533\n",
+            "  nanos: 587977000\n",
+            "}\n",
+            "\n"
+          ]
+        }
+      ],
       "source": [
         "example_corpus = glm.Corpus(display_name=\"Google for Developers Blog\")\n",
         "create_corpus_request = glm.CreateCorpusRequest(corpus=example_corpus)\n",

--- a/site/en/tutorials/prompting_with_media.ipynb
+++ b/site/en/tutorials/prompting_with_media.ipynb
@@ -218,7 +218,15 @@
       "metadata": {
         "id": "N9NxXGZKKusG"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Uploaded file 'Sample drawing' as: https://generativelanguage.googleapis.com/v1beta/files/ui00j5zfuqe0\n"
+          ]
+        }
+      ],
       "source": [
         "sample_file = genai.upload_file(path=\"image.jpg\",\n",
         "                            display_name=\"Sample drawing\")\n",


### PR DESCRIPTION
These are needed so that we don't try and execute them on import.