### PR TITLE
Fix broken links in notebooks

### DIFF
--- a/site/en/gemini-api/docs/model-tuning/rest.ipynb
+++ b/site/en/gemini-api/docs/model-tuning/rest.ipynb
@@ -105,7 +105,7 @@
         "your tuned models this needs stricter access controls than API-Keys can provide.\n",
         "\n",
         "Before you can run this tutorial, you'll need to\n",
-        "[setup OAuth for your project](oauth_quickstart.ipynb).\n",
+        "[setup OAuth for your project](https://ai.google.dev/gemini-api/docs/oauth).\n",
         "\n",
         "\n",
         "In Colab the easiest wat to get setup is to copy the contents of your `client_secret.json` file into Colab's \"Secrets manager\" (under the key icon in the left panel) with the secret name `CLIENT_SECRET`."
@@ -553,7 +553,7 @@
       "source": [
         "The output from your model may or may not be correct. If the tuned model isn't performing up to your required standards, you can try adding more high quality examples, tweaking the hyperparameters or adding a preamble to your examples. You can even create another tuned model based on the first one you created.\n",
         "\n",
-        "See the [tuning guide](../guide/model_tuning_guidance) for more guidance on improving performance."
+        "See the [tuning guide](https://ai.google.dev/gemini-api/docs/model-tuning) for more guidance on improving performance."
       ]
     },
     {

--- a/site/en/gemini-api/docs/semantic_retrieval.ipynb
+++ b/site/en/gemini-api/docs/semantic_retrieval.ipynb
@@ -113,7 +113,7 @@
       "source": [
         "## Authenticate\n",
         "\n",
-        "The Semantic Retriever API lets you perform semantic search on your own data. Since it's **your data**, this needs stricter access controls than API keys. Authenticate with OAuth with [service accounts](#scrollTo=eLjhFIOQ7_Dk) or through your [user credentials](#scrollTo=9YGv4x9ehLba).\n",
+        "The Semantic Retriever API lets you perform semantic search on your own data. Since it's **your data**, this needs stricter access controls than API keys. Authenticate with OAuth with [service accounts](#service-oauth) or through your [user credentials](#user-oauth).\n",
         "\n",
         "This quickstart uses a simplified authentication approach meant for a testing environment, and service account setups are typically easier to start from. For a production environment, learn about [authentication and authorization](https://developers.google.com/workspace/guides/auth-overview){:.external} before choosing the [access credentials](https://developers.google.com/workspace/guides/create-credentials#choose_the_access_credential_that_is_right_for_you){:.external} that are appropriate for your app.\n"
       ]
@@ -124,7 +124,7 @@
         "id": "eLjhFIOQ7_Dk"
       },
       "source": [
-        "### Setup OAuth using service accounts\n",
+        "### Setup OAuth using service accounts {:#service-oauth}\n",
         "\n",
         "Follow the steps below to setup OAuth using service accounts:\n",
         "\n",
@@ -204,7 +204,7 @@
         "id": "4EQJD2PWD56T"
       },
       "source": [
-        "## Create a corpus\n",
+        "## Create a corpus {:#create-corpus}\n",
         "\n",
         "The Semantic Retriever API lets you define up to 5 custom text corpora per project. You can specify either of the following fields while defining your corpora:\n",
         "\n",
@@ -952,7 +952,7 @@
         "id": "9YGv4x9ehLba"
       },
       "source": [
-        "## Appendix: Setup OAuth with user credentials\n",
+        "## Appendix: Setup OAuth with user credentials {:#user-oauth}\n",
         "\n",
         "Follow the steps below from the [OAuth Quickstart](https://ai.google.dev/docs/oauth_quickstart) to setup OAuth authentication.\n",
         "\n",
@@ -995,7 +995,7 @@
         "id": "lybTOlN9gz0I"
       },
       "source": [
-        "Initialize the client library and re-run the notebook starting from [Create a corpus](#scrollTo=4EQJD2PWD56T)."
+        "Initialize the client library and re-run the notebook starting from [Create a corpus](#create-corpus)."
       ]
     },
     {


### PR DESCRIPTION
## Description of the change
Links were broken. Now they're not.

A couple of these were relative paths that were moved, but there were some instances of links using Colab's `scrollTo` notation, which doesn't work outside of Colab.