### PR TITLE
Replace staging links with prod

### DIFF
--- a/site/en/gemini-api/docs/model-tuning/python.ipynb
+++ b/site/en/gemini-api/docs/model-tuning/python.ipynb
@@ -518,7 +518,7 @@
         "id": "lqiL0TWDqAPn"
       },
       "source": [
-        "Once the tuning is complete, you can view the loss curve from the tuning results. The [loss curve](https://generativeai.devsite.corp.google.com/guide/model_tuning_guidance#recommended_configurations) shows how much the model's predictions deviate from the ideal outputs."
+        "Once the tuning is complete, you can view the loss curve from the tuning results. The [loss curve](https://ai.google.dev/gemini-api/docs/model-tuning#recommended_configurations) shows how much the model's predictions deviate from the ideal outputs."
       ]
     },
     {

--- a/site/en/palm_docs/tuning_quickstart_python.ipynb
+++ b/site/en/palm_docs/tuning_quickstart_python.ipynb
@@ -526,7 +526,7 @@
         "id": "lqiL0TWDqAPn"
       },
       "source": [
-        "Once the tuning is complete, you can view the loss curve from the tuning results. The [loss curve](https://generativeai.devsite.corp.google.com/guide/model_tuning_guidance#recommended_configurations) shows how much the model's predictions deviate from the ideal outputs."
+        "Once the tuning is complete, you can view the loss curve from the tuning results. The [loss curve](https://ai.google.dev/gemini-api/docs/model-tuning#recommended_configurations) shows how much the model's predictions deviate from the ideal outputs."
       ]
     },
     {
@@ -668,7 +668,7 @@
       "source": [
         "As you can see, the last prompt didn't produce the ideal result, `five`. To produce better results you can try a few different things such as adjusting the temperature closer to zero to get more consistent results, adding more quality examples to your dataset that the model can learn from or adding a prompt or preamble to the examples.\n",
         "\n",
-        "See the [tuning guide](https://generativeai.devsite.corp.google.com/guide/model_tuning_guidance) for more guidance on improving performance."
+        "See the [tuning guide](https://ai.google.dev/gemini-api/docs/model-tuning) for more guidance on improving performance."
       ]
     },
     {


### PR DESCRIPTION
Looks like these slipped through the cracks.

Also updated to point to the new path.