### PR TITLE
Normalize the Python package name to "google-generativeai"

### DIFF
--- a/examples/gemini/python/vectordb_with_chroma/vectordb_with_chroma.ipynb
+++ b/examples/gemini/python/vectordb_with_chroma/vectordb_with_chroma.ipynb
@@ -101,7 +101,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -U -q google.generativeai"
+        "!pip install -U -q google-generativeai"
       ]
     },
     {

--- a/site/en/docs/react_gemini_prompting.ipynb
+++ b/site/en/docs/react_gemini_prompting.ipynb
@@ -157,7 +157,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q google.generativeai"
+        "!pip install -q google-generativeai"
       ]
     },
     {

--- a/site/en/examples/chat_calculator.ipynb
+++ b/site/en/examples/chat_calculator.ipynb
@@ -86,7 +86,7 @@
       },
       "outputs": [],
       "source": [
-        "pip install -q google.generativeai"
+        "pip install -q google-generativeai"
       ]
     },
     {

--- a/site/en/examples/text_calculator.ipynb
+++ b/site/en/examples/text_calculator.ipynb
@@ -95,7 +95,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q google.generativeai"
+        "!pip install -q google-generativeai"
       ]
     },
     {

--- a/site/en/gemini-api/tutorials/anomaly_detection.ipynb
+++ b/site/en/gemini-api/tutorials/anomaly_detection.ipynb
@@ -92,7 +92,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -U -q google.generativeai"
+        "!pip install -U -q google-generativeai"
       ]
     },
     {

--- a/site/en/gemini-api/tutorials/clustering_with_embeddings.ipynb
+++ b/site/en/gemini-api/tutorials/clustering_with_embeddings.ipynb
@@ -93,7 +93,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -U -q google.generativeai"
+        "!pip install -U -q google-generativeai"
       ]
     },
     {

--- a/site/en/gemini-api/tutorials/document_search.ipynb
+++ b/site/en/gemini-api/tutorials/document_search.ipynb
@@ -93,7 +93,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -U -q google.generativeai"
+        "!pip install -U -q google-generativeai"
       ]
     },
     {

--- a/site/en/gemini-api/tutorials/text_classifier_embeddings.ipynb
+++ b/site/en/gemini-api/tutorials/text_classifier_embeddings.ipynb
@@ -93,7 +93,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -U -q google.generativeai"
+        "!pip install -U -q google-generativeai"
       ]
     },
     {


### PR DESCRIPTION
## Description of the change
The package name `google-generativeai` was written as `google.generativeai` which is incorrect.

## Motivation
Use the correct package name on the pip install command.

## Type of change
Choose one: Bug fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
