### PR TITLE
Fixed "model = model = model" typo in tutorial

### DIFF
--- a/site/en/gemini-api/tutorials/extract_structured_data.ipynb
+++ b/site/en/gemini-api/tutorials/extract_structured_data.ipynb
@@ -260,7 +260,7 @@
       },
       "outputs": [],
       "source": [
-        "model = model = model = genai.GenerativeModel(\n",
+        "model = genai.GenerativeModel(\n",
         "    model_name='models/gemini-1.5-pro-latest')\n",
         "\n",
         "response = model.generate_content(\n",


### PR DESCRIPTION
## Description of the change
Updated [tutorial](https://ai.google.dev/gemini-api/tutorials/extract_structured_data)

## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->
Typo fix

## Type of change
Choose one: (Bug fix)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
