### PR TITLE
Add `generateContent` text samples for Python and rest

### DIFF
--- a/examples/gemini/python/api/generatecontent_text.py
+++ b/examples/gemini/python/api/generatecontent_text.py
@@ -1,0 +1,9 @@
+import os
+import google.generativeai as genai
+
+genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
+
+model = genai.GenerativeModel("gemini-1.5-flash")
+
+response = model.generate_content("Give me python code to sort a list")
+print(response.text)

--- a/examples/gemini/rest/api/generatecontent_text.sh
+++ b/examples/gemini/rest/api/generatecontent_text.sh
@@ -1,0 +1,8 @@
+curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${GOOGLE_API_KEY}" \
+    -H 'Content-Type: application/json' \
+    -X POST \
+    -d '{
+      "contents": [{
+        "parts":[{"text": "Give me python code to sort a list."}]
+        }]
+       }'


### PR DESCRIPTION
This sets up new directories for API samples and adds a full-file sample for both Python and REST/curl.