### PR TITLE
[Docs Agent] Bug fix: Prevent the AQA model from failing when a response returns entries containing a null string

### DIFF
--- a/examples/gemini/python/docs-agent/README.md
+++ b/examples/gemini/python/docs-agent/README.md
@@ -31,6 +31,23 @@ stored in the [`tasks`][tasks-dir] directory of your Docs Agent project. The tas
 designed to be reusable and can be used to automate common workflows, such as generating
 release notes, updating documentation, or analyzing complex information.
 
+A task file example:
+
+```yaml
+tasks:
+  - name: "ExtractWorkflows"
+    model: "models/gemini-1.5-flash-latest"
+    description: "An agent that extracts workflows from a source doc."
+    steps:
+      - prompt: "Summarize the contents of this document in a concise and informative manner. Focus on the key procedures, steps, or workflows described."
+        flags:
+          file: "<INPUT>"
+          default_input: "./README.md"
+      - prompt: "Identify and list all key workflows described in the document. Provide a brief description for each workflow, highlighting its purpose and key steps."
+      - prompt: "Identify all command lines used in the workflows described in the document. Focus on command lines that are essential for executing the workflow steps."
+      - prompt: "For each identified command line, provide a detailed description of its function and purpose. Include specific examples of its usage, showcasing how it is integrated within the workflows."
+```
+
 To set up and run the `agent runtask` command, see [Set up Docs Agent CLI][cli-readme].
 
 ## Summary of features

--- a/examples/gemini/python/docs-agent/docs_agent/preprocess/splitters/markdown_splitter.py
+++ b/examples/gemini/python/docs-agent/docs_agent/preprocess/splitters/markdown_splitter.py
@@ -119,7 +119,7 @@ Content hash: {self.md_hash}\n"
 
 
 def DictionarytoSection(metadata: dict) -> Section:
-    if "section_id" in metadata:
+    if "section_id" in metadata and metadata["section_id"] != '':
         section_id = int(metadata["section_id"])
     else:
         section_id = ""
@@ -135,11 +135,11 @@ def DictionarytoSection(metadata: dict) -> Section:
         page_title = str(metadata["page_title"])
     else:
         page_title = ""
-    if "section_level" in metadata:
+    if "section_level" in metadata and metadata["section_level"] != '':
         section_level = int(metadata["section_level"])
     else:
         section_level = ""
-    if "previous_id" in metadata:
+    if "previous_id" in metadata and metadata["previous_id"] != '':
         previous_id = int(metadata["previous_id"])
     else:
         previous_id = ""
@@ -147,7 +147,7 @@ def DictionarytoSection(metadata: dict) -> Section:
         parent_tree = metadata["parent_tree"]
     else:
         parent_tree = []
-    if "token_estimate" in metadata:
+    if "token_estimate" in metadata and metadata["token_estimate"] != '':
         token_estimate = int(metadata["token_estimate"])
     else:
         token_estimate = ""

--- a/examples/gemini/python/docs-agent/tasks/extract-workflows-task.yaml
+++ b/examples/gemini/python/docs-agent/tasks/extract-workflows-task.yaml
@@ -8,5 +8,5 @@ tasks:
           file: "<INPUT>"
           default_input: "./README.md"
       - prompt: "Identify and list all key workflows described in the document. Provide a brief description for each workflow, highlighting its purpose and key steps."
-      - prompt: "Identify all command lines used in the workflows described in the document.  Focus on command lines that are essential for executing the workflow steps."
-      - prompt: "For each identified command line, provide a detailed description of its function and purpose.  Include specific examples of its usage, showcasing how it is integrated within the workflows."
+      - prompt: "Identify all command lines used in the workflows described in the document. Focus on command lines that are essential for executing the workflow steps."
+      - prompt: "For each identified command line, provide a detailed description of its function and purpose. Include specific examples of its usage, showcasing how it is integrated within the workflows."

--- a/examples/gemini/python/docs-agent/tasks/release-notes-task.yaml
+++ b/examples/gemini/python/docs-agent/tasks/release-notes-task.yaml
@@ -1,16 +1,13 @@
 tasks:
   - name: "DraftReleaseNotes"
-    model: "models/gemini-1.5-flash-latest"
+    model: "models/gemini-1.5-flash"
     description: "An agent that generates a draft of Docs Agent release notes from git commit messages."
+    preamble: "When generating release notes, limit the total number of key features and updates to 5 or fewer entries."
     steps:
-      - name: "Read git commit messages"
-        description: "Load the git log commit messages from the local Fuchsia checkout since a target date."
+      - prompt: "git --no-pager log --since=2024-06-15"
         function: "posix"
-        prompt: "git --no-pager log --since=2024-05-26"
-      - name: "Create an initial release notes draft"
-        function: "helpme"
-        prompt: "Based on the commit messages above, create an initial release notes draft that introduces new features and brings attention to important messages."
-      - name: "Revise the release notes draft"
-        function: "helpme"
-        prompt: "Revise the release notes draft above to be more concise and better structured, and if appropriate, include practical examples."
+        description: "Load the git log commit messages from the local Docs Agent checkout since a target date."
+      - prompt: "Please extract a list of key features and improvements from the provided git log commit messages, focusing on those that are most impactful and relevant for developers."
+      - prompt: "Based on the extracted key features and improvements, write a concise and informative release notes draft. Use clear and concise language, focusing on the benefits and value provided to developers."
+      - prompt: "Revise the release notes draft to enhance readability and structure. Format the release notes using bullet points for clarity and limit each entry to a maximum of two sentences."
 


### PR DESCRIPTION
## Description of the change
- Prevent the AQA model from failing when its response's metadata returns entries containing an empty string.
- Update the `DraftReleaseNotes` tasks with polished prompts.
- Add a task file example to the main `README.md` file.
- Minor update in the `ExtractWorkflows` task to remove extra spaces.

## Motivation
Bug fix mainly

## Type of change
Choose one: (Bug fix)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [ X] I have performed a self-review of my code.
- [ X] I have added detailed comments to my code where applicable.
- [ X] I have verified that my change does not break existing code.
- [ X] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ X] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ X] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
