### PR TITLE
Corrected URL path to access the Kaggle Gemma model weights dir

### DIFF
--- a/site/en/gemma/docs/pytorch_gemma.ipynb
+++ b/site/en/gemma/docs/pytorch_gemma.ipynb
@@ -186,7 +186,7 @@
         "import kagglehub\n",
         "\n",
         "# Load model weights\n",
-        "weights_dir = kagglehub.model_download(f'google/gemma-2-2b/pyTorch/gemma-2-{VARIANT}')"
+        "weights_dir = kagglehub.model_download(f'google/gemma-2/pyTorch/gemma-2-{VARIANT}')"
       ]
     },
     {


### PR DESCRIPTION


## Description of the change
I have corrected incorrect URL for accessing the Kaggle Gemma-2 model checkpoint and weight directory from "google/gemma-2-2b/pyTorch/gemma-2-{VARIANT}" to "google/gemma-2/pyTorch/gemma-2-{VARIANT}". 

I have updated the URL after verifying on the Kaggle platform and also have successfully implemented and tested in a Colab environment. 

Please find the replicated [gist](https://colab.sandbox.google.com/gist/RenuPatelGoogle/711a744401b32b30048c2f100d0ab7d2/kaggle_gemma2.ipynb) here for the same.

## Motivation
User-reported an issue on Kaggle for the same -[#535372](https://www.kaggle.com/models/google/gemma-2/discussion/535372). While investigating the issue,I have found that a URL mismatch was causing this error. Error got resolved after correcting the URL and code run successfully.. 
## Type of change

Code Fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [ ] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [ ] I have verified that my change does not break existing code.
- [ ] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
