### PR TITLE
PaliGemma model Code Correction: Model Name & Documentation Link

### DIFF
--- a/site/en/gemma/docs/paligemma/inference-with-keras.ipynb
+++ b/site/en/gemma/docs/paligemma/inference-with-keras.ipynb
@@ -260,7 +260,7 @@
       },
       "outputs": [],
       "source": [
-        "paligemma = keras_hub.models.PaliGemmaCausalLM.from_preset(\"paligemma_3b_mix_224\")\n",
+        "paligemma = keras_hub.models.PaliGemmaCausalLM.from_preset(\"pali_gemma_3b_mix_224\")\n",
         "paligemma.summary()"
       ]
     },
@@ -393,7 +393,7 @@
       "source": [
         "## Generate output\n",
         "\n",
-        "After loading the model and creating utility methods, you can prompt the model with image and text data to generate a responses. PaliGemma models are trained with specific prompt syntax for specific tasks, such as `answer`, `caption`, and `detect`. For more information about PaliGemma prompt task syntax, see [PaliGemma prompt and system instructions](https://ai.google.com/gemma/docs/paligemma/prompt-system-instructions##prompt_task_syntax).\n",
+        "After loading the model and creating utility methods, you can prompt the model with image and text data to generate a responses. PaliGemma models are trained with specific prompt syntax for specific tasks, such as `answer`, `caption`, and `detect`. For more information about PaliGemma prompt task syntax, see [PaliGemma prompt and system instructions](https://ai.google.dev/gemma/docs/paligemma/prompt-system-instructions##prompt_task_syntax).\n",
         "\n",
         "Prepare an image for use in a generation prompt by using the following code to load a test image into an object:"
       ]

--- a/site/en/gemma/docs/paligemma/inference-with-keras.ipynb
+++ b/site/en/gemma/docs/paligemma/inference-with-keras.ipynb
@@ -51,7 +51,7 @@
         "\n",
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
         "<td>\n",
-        "<a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/paligemma/fine-tuning-paligemma\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
+        "<a target=\"_blank\" href=\"https://ai.google.dev/gemma/docs/paligemma/inference-with-keras\"><img src=\"https://ai.google.dev/static/site-assets/images/docs/notebook-site-button.png\" height=\"32\" width=\"32\" />View on ai.google.dev</a>\n",
         "</td>\n",
         "<td>\n",
         "<a target=\"_blank\" href=\"https://colab.research.google.com/github/google/generative-ai-docs/blob/main/site/en/gemma/docs/paligemma/inference-with-keras.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",


### PR DESCRIPTION


## Description of the change
**Typo:** Fixed the model name in the code - `paligemma = keras_hub.models.PaliGemmaCausalLM.from_preset("paligemma_3b_mix_224")` from "paligemma_3b_mix_224" to "pali_gemma_3b_mix_224" to correctly load the model.
**Broken Link:** Updated the URL for "PaliGemma prompt and system instructions" by replacing the existing URL with the correct URL - https://ai.google.dev/gemma/docs/paligemma/prompt-system-instructions/##prompt_task_syntax.

## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->

## Type of change
Choose one: (Bug fix)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [ ] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [ ] I have verified that my change does not break existing code.
- [ ] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [ ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
