### PR TITLE
Update vision.ipynb by fixing the typo in code

### DIFF
--- a/site/en/gemini-api/docs/vision.ipynb
+++ b/site/en/gemini-api/docs/vision.ipynb
@@ -782,7 +782,7 @@
         "print(\"Making LLM inference request...\")\n",
         "response = model.generate_content([video_file, prompt],\n",
         "                                  request_options={\"timeout\": 600})\n",
-        "Markdown(esponse.text)"
+        "Markdown(response.text)"
       ]
     },
     {


### PR DESCRIPTION
Fixed the typo mistake at code `Markdown(esponse.text)` in the  'Transcribe video and provide visual descriptions' section in 'vision' doc which gives `NameError: name 'esponse' is not defined` while code exceution.

Fixed the typo by adding 'r' in code `Markdown(response.text)`.