### PR TITLE
fix(examples): correct formatting, grammar, and MMLU acronym in llama_chroma_qa example

### DIFF
--- a/examples/gemini/python/llamaindex/Gemini_LlamaIndex_QA_Chroma_WebPageReader.ipynb
+++ b/examples/gemini/python/llamaindex/Gemini_LlamaIndex_QA_Chroma_WebPageReader.ipynb
@@ -66,7 +66,7 @@
         "\n",
         "[Gemini](https://ai.google.dev/models/gemini) is a family of generative AI models that lets developers generate content and solve problems. These models are designed and trained to handle both text and images as input.\n",
         "\n",
-        "[LlamaIndex](https://www.llamaindex.ai/) is a simple, flexible data framework that can be used by Large Language Model(LLM) applications to connect custom data sources to LLMs.\n",
+        "[LlamaIndex](https://www.llamaindex.ai/) is a simple, flexible data framework that can be used by Large Language Model (LLM) applications to connect custom data sources to LLMs.\n",
         "\n",
         "[Chroma](https://docs.trychroma.com/) is an open-source embedding database focused on simplicity and developer productivity. Chroma allows users to store embeddings and their metadata, embed documents and queries, and search the embeddings quickly.\n",
         "\n",
@@ -336,7 +336,7 @@
         "id": "TamoAP7ckyvB"
       },
       "source": [
-        "You can use variety of HTML parsers to extract the required text from the html content.\n",
+        "You can use a variety of HTML parsers to extract the required text from the html content.\n",
         "\n",
         "In this example, you'll use Python's `BeautifulSoup` library to parse the website data. After processing, the extracted text should be converted back to LlamaIndex's `Document` format."
       ]
@@ -517,7 +517,7 @@
         ")\n",
         "\n",
         "# Check if the retriever is working by trying to fetch the relevant docs related\n",
-        "# to the phrase 'MMLU' (Multimodal Machine Learning Understanding).\n",
+        "# to the phrase 'MMLU' (Massive Multitask Language Understanding).\n",
         "# If the length is greater than zero, it means that the retriever is\n",
         "# functioning well.\n",
         "# You can ask questions about your data using a generic interface called\n",


### PR DESCRIPTION
## Description of the change
Corrects minor formatting, grammar, and a factual error within the `examples/gemini/python/llamaindex/Gemini_LlamaIndex_QA_Chroma_WebPageReader.ipynb` example notebook.

Specifically:
- Added space before parenthesis in `Model (LLM)`.
- Fixed grammar with `a variety of`.
- Corrected the expansion of the `MMLU` acronym in a code comment.

## Motivation
To improve the readability, grammatical correctness, and factual accuracy of the example notebook.

## Type of change
Documentation

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
