### PR TITLE
fix(examples): correct WebBaseLoader typo in LangChain QA examples

### DIFF
--- a/examples/gemini/python/langchain/Gemini_LangChain_QA_Chroma_WebLoad.ipynb
+++ b/examples/gemini/python/langchain/Gemini_LangChain_QA_Chroma_WebLoad.ipynb
@@ -403,7 +403,7 @@
         "\n",
         "To create a Chroma vector database from the website data, you will use the `from_documents` function of `Chroma`. Under the hood, this function creates embeddings from the documents created by the document loader of LangChain using any specified embedding model and stores them in a Chroma vector database.  \n",
         "\n",
-        "You have to specify the `docs` you created from the website data using LangChain's `WebBasedLoader` and the `gemini_embeddings` as the embedding model when invoking the `from_documents` function to create the vector database from the website data. You can also specify a directory in the `persist_directory` argument to store the vector store on the disk. If you don't specify a directory, the data will be ephemeral in-memory.\n"
+        "You have to specify the `docs` you created from the website data using LangChain's `WebBaseLoader` and the `gemini_embeddings` as the embedding model when invoking the `from_documents` function to create the vector database from the website data. You can also specify a directory in the `persist_directory` argument to store the vector store on the disk. If you don't specify a directory, the data will be ephemeral in-memory.\n"
       ]
     },
     {

--- a/examples/gemini/python/langchain/Gemini_LangChain_QA_Pinecone_WebLoad.ipynb
+++ b/examples/gemini/python/langchain/Gemini_LangChain_QA_Pinecone_WebLoad.ipynb
@@ -449,7 +449,7 @@
         "\n",
         "Next, you'll insert the documents you extracted earlier from the website data into the newly created index using LangChain's `Pinecone.from_documents`. Under the hood, this function creates embeddings from the documents created by the document loader of LangChain using any specified embedding model and inserts them into the specified index in a Pinecone vector database.  \n",
         "\n",
-        "You have to specify the `docs` you created from the website data using LangChain's `WebBasedLoader` and the `gemini_embeddings` as the embedding model when invoking the `from_documents` function to create the vector database from the website data."
+        "You have to specify the `docs` you created from the website data using LangChain's `WebBaseLoader` and the `gemini_embeddings` as the embedding model when invoking the `from_documents` function to create the vector database from the website data."
       ]
     },
     {


### PR DESCRIPTION
## Description of the change
Corrects a recurring typo in the class name `WebBaseLoader` (incorrectly written as `WebBasedLoader`) within the documentation text of two LangChain QA example notebooks:
- `examples/gemini/python/langchain/Gemini_LangChain_QA_Chroma_WebLoad.ipynb`
- `examples/gemini/python/langchain/Gemini_LangChain_QA_Pinecone_WebLoad.ipynb`

## Motivation
To ensure the correct class name is referenced in the documentation, improving accuracy and preventing potential confusion for users copying code or commands.

## Type of change
Documentation

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
