### PR TITLE
Fix broken link in transformers guide

### DIFF
--- a/site/en/gemma/docs/core/huggingface_inference.ipynb
+++ b/site/en/gemma/docs/core/huggingface_inference.ipynb
@@ -191,7 +191,7 @@
         "id": "eqtJZPHPP1b5"
       },
       "source": [
-        "Gemma supports only a few `task` settings for generation. For more information on the available `task` settings, see the Hugging Face Pipelines [task()](https://huggingface.co/docs/transformers/main/en/main_classes/pipelines#transformers.pipeline.task) documentation. Use the torch data type `torch.bfloat16` to reduce the precision of the model and compute resources needed, without significantly impacting the output quality of the model. For the `device` setting, you can use `\"cuda\"` for Colab, or `\"msu\"` for iOS devices, or just set this to `0` (zero) to specify the first GPU on your system. For more information about using the Pipeline class, see the Hugging Face [Pipelines](https://huggingface.co/docs/transformers/main/en/main_classes/) documentation."
+        "Gemma supports only a few `task` settings for generation. For more information on the available `task` settings, see the Hugging Face Pipelines [task()](https://huggingface.co/docs/transformers/main/en/main_classes/pipelines#transformers.pipeline.task) documentation. Use the torch data type `torch.bfloat16` to reduce the precision of the model and compute resources needed, without significantly impacting the output quality of the model. For the `device` setting, you can use `\"cuda\"` for Colab, or `\"msu\"` for iOS devices, or just set this to `0` (zero) to specify the first GPU on your system. For more information about using the Pipeline class, see the Hugging Face [Pipelines](https://huggingface.co/docs/transformers/main/en/main_classes/pipelines) documentation."
       ]
     },
     {


### PR DESCRIPTION
## Description of the change
The current url to the transformers doc is broken

## Type of change
Choose one: Bug fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
