### PR TITLE
Notebook update for Gemma 3n on HF - fix typo

### DIFF
--- a/site/en/gemma/docs/core/huggingface_inference.ipynb
+++ b/site/en/gemma/docs/core/huggingface_inference.ipynb
@@ -502,7 +502,7 @@
         "id": "vpp8tZDFU-UJ"
       },
       "source": [
-        "You can include multiple images in your prompt by including additional `\"type\": \"audio\",` entries in the `content` list. If you are prompting with audio data, but without a template, use the `<audio_soft_token>` syntax in the text of your prompt.\n",
+        "You can include multiple audio files in your prompt by including additional `\"type\": \"audio\",` entries in the `content` list. If you are prompting with audio data, but without a template, use the `<audio_soft_token>` syntax in the text of your prompt.\n",
         "\n",
         "Note: Do not use `<audio_soft_token>` tokens in text portion of a prompt template as this approach creates redundant tokens and processing errors. The Transformers library uses `<audio_soft_token>` as a placeholder for images in prompts, rather than `<start_of_audio>` for consistency across models."
       ]


### PR DESCRIPTION
## Description of the change
The audio section of the HF Transformers inference notebook referred to images erroneously instead of audio files.

## Motivation
It was inaccurate to say "images" there.

## Type of change
Documentation

## Checklist
- [X] I have performed a self-review of my code.
- [-] I have added detailed comments to my code where applicable.
- [X] I have verified that my change does not break existing code.
- [X] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [X] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [X] I have read through the [Contributing Guide](https://github.com/google/generative-ai-docs/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
